### PR TITLE
Corrected `to_qualified` function for identificators

### DIFF
--- a/libindy_vdr/src/ledger/identifiers/cred_def.rs
+++ b/libindy_vdr/src/ledger/identifiers/cred_def.rs
@@ -151,11 +151,8 @@ impl Qualifiable for CredentialDefinitionId {
     fn combine(method: Option<&str>, entity: &str) -> Self {
         let cid = Self(entity.to_owned());
         match cid.parts() {
-            Some((_, did, sigtype, schema_id, tag)) => Self::from(qualifier::combine(
-                Self::PREFIX,
-                method,
-                Self::new(&did.default_method(method), &schema_id, &sigtype, &tag).as_str(),
-            )),
+            Some((_, did, sigtype, schema_id, tag)) =>
+                Self::new(&did.default_method(method), &schema_id.default_method(method), &sigtype, &tag),
             None => cid,
         }
     }
@@ -403,6 +400,15 @@ mod tests {
             _cred_def_id_qualified_with_schema_as_seq_no()
                 .validate()
                 .unwrap();
+        }
+    }
+
+    mod to_qualified {
+        use super::*;
+
+        #[test]
+        fn test_red_def_to_qualified() {
+            assert_eq!(_cred_def_id_unqualified().to_qualified("sov").unwrap(), _cred_def_id_qualified())
         }
     }
 }

--- a/libindy_vdr/src/ledger/identifiers/rev_reg.rs
+++ b/libindy_vdr/src/ledger/identifiers/rev_reg.rs
@@ -59,6 +59,15 @@ impl Qualifiable for RevocationRegistryId {
         Self::PREFIX
     }
 
+    fn combine(method: Option<&str>, entity: &str) -> Self {
+        let sid = Self(entity.to_owned());
+        match sid.parts() {
+            Some((did, cred_def_id, rev_reg_type, tag)) =>
+                Self::new(&did.default_method(method), &cred_def_id.default_method(method), &rev_reg_type, &tag),
+            None => sid,
+        }
+    }
+
     fn to_unqualified(&self) -> Self {
         match self.parts() {
             Some((did, cred_def_id, rev_reg_type, tag)) => Self::new(
@@ -173,6 +182,15 @@ mod tests {
         #[test]
         fn test_validate_rev_reg_id_as_fully_qualified() {
             _rev_reg_id_qualified().validate().unwrap();
+        }
+    }
+
+    mod to_qualified {
+        use super::*;
+
+        #[test]
+        fn test_red_def_to_qualified() {
+            assert_eq!(_rev_reg_id_unqualified().to_qualified("sov").unwrap(), _rev_reg_id_qualified())
         }
     }
 }

--- a/libindy_vdr/src/ledger/identifiers/schema.rs
+++ b/libindy_vdr/src/ledger/identifiers/schema.rs
@@ -65,11 +65,8 @@ impl Qualifiable for SchemaId {
     fn combine(method: Option<&str>, entity: &str) -> Self {
         let sid = Self(entity.to_owned());
         match sid.parts() {
-            Some((_, did, name, version)) => Self::from(qualifier::combine(
-                Self::PREFIX,
-                method,
-                Self::new(&did.default_method(method), &name, &version).as_str(),
-            )),
+            Some((_, did, name, version)) =>
+                Self::new(&did.default_method(method), &name, &version),
             None => sid,
         }
     }
@@ -215,6 +212,15 @@ mod tests {
         fn test_validate_schema_id_for_invalid_fully_qualified() {
             let id = SchemaId("schema:sov:NcYxiDXkpYi6ov5FcYDi1e:2:1.0".to_string());
             id.validate().unwrap_err();
+        }
+    }
+
+    mod to_qualified {
+        use super::*;
+
+        #[test]
+        fn test_schema_to_qualified() {
+            assert_eq!(_schema_id_unqualified().to_qualified("sov").unwrap(), _schema_id_qualified())
         }
     }
 }


### PR DESCRIPTION
Corrected behavior of `to_qualified` functions for public identificators. The previous implementation returned `schema:sov:schema:sov:did:sov:7ehexq99JSmcKrJKmydegi:2:gvt:1.0` for SchemaId and similar for others. 
Signed-off-by: artem.ivanov <artem.ivanov@dsr-company.com>