### PR TITLE
Update proxy response format, add pool auto-refresh

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -658,6 +658,7 @@ version = "0.1.0"
 dependencies = [
  "clap",
  "env_logger",
+ "futures",
  "hyper",
  "hyper-tls",
  "hyper-unix-connector",
@@ -1403,7 +1404,19 @@ dependencies = [
  "pin-project-lite",
  "signal-hook-registry",
  "slab",
+ "tokio-macros",
  "winapi 0.3.8",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0c3acc6aa564495a0f2e1d59fab677cd7f81a19994cfc7f3ad0e64301560389"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Indy-VDR
+# Indy-VDR (Verifiable Data Registry)
 
 [<img src="https://raw.githubusercontent.com/hyperledger/indy-node/master/collateral/logos/indy-logo.png" width="50%" height="auto">](https://github.com/hyperledger/indy-sdk/)
 
@@ -14,7 +14,7 @@
 
 ## Introduction
 
-This library is derived from [Hyperledger Indy SDK](https://github.com/hyperledger/indy-sdk) for the more limited use case of connecting to an Indy Node blockchain ledger, a Verifiable Data Registry. It is written in Rust and currently includes a Python wrapper and a standalone proxy server.
+This library is derived from [Hyperledger Indy SDK](https://github.com/hyperledger/indy-sdk) for the more limited use case of connecting to an [Indy Node](https://github.com/hyperledger/indy-node) blockchain ledger. It is written in Rust and currently includes a Python wrapper and a standalone proxy server.
 
 _This library is still in development and there are currently no standard release packages._
 
@@ -40,7 +40,9 @@ At a later stage it should be possible to install a precompiled 'wheel' package 
 
 The `indy-vdr-proxy` executable can be used to provide a simple REST API for interacting with the ledger. Command line options can be inspected by running `indy-vdr-proxy --help`.
 
-Sending prepared requests to the ledger is performed by delivering a POST request to the `/submit` endpoint. Additional endpoints are provided as shortcuts for ledger read transactions:
+Responses can be formatted in either HTML or JSON formats. HTML formatting is selected when the `text/html` content type is requested according to the Accept header (as sent by web browsers) or the request query string is set to `?html`. JSON formatting is selected otherwise, and may be explitly selected by using the query string `?raw`. For most ledger requests, JSON responses include information regarding which nodes were contacted is returned in the `X-Requests` header.
+
+Sending prepared requests to the ledger is performed by delivering a POST request to the `/submit` endpoint, where the body of the request is the JSON-formatted payload. Additional endpoints are provided as shortcuts for ledger read transactions:
 
 - `/` The root path shows basic status information about the server and the ledger pool
 - `/genesis` Return the current set of genesis transactions

--- a/indy-vdr-proxy/Cargo.toml
+++ b/indy-vdr-proxy/Cargo.toml
@@ -15,13 +15,14 @@ default = ["fetch", "zmq_vendored"]
 [dependencies]
 clap = "2.33.0"
 env_logger = "0.7.1"
+futures = "0.3.1"
 hyper = "0.13.0"
 hyper-tls = { version = "0.4.1", optional = true }
 hyper-unix-connector = "0.1.4"
 log = "0.4.8"
 percent-encoding = "2.1.0"
 serde_json = "1.0.40"
-tokio = { version = "0.2.9", features = ["rt-util", "signal"] }
+tokio = { version = "0.2.9", features = ["macros", "rt-util", "signal"] }
 indy-vdr = { path = "../libindy_vdr", default-features = false, features = ["log"] }
 
 [[bin]]

--- a/indy-vdr-proxy/src/app.rs
+++ b/indy-vdr-proxy/src/app.rs
@@ -7,50 +7,58 @@ pub struct Config {
     pub host: Option<String>,
     pub port: Option<u16>,
     pub init_refresh: bool,
+    pub interval_refresh: u32,
 }
 
 pub fn load_config() -> Result<Config, String> {
     let matches = App::new("indy-vdr-proxy")
         .version("0.1.0")
-        // .author("Andrew Whitehead")
-        .about("Proxy requests to a Hyperledger Indy ledger")
+        .about("Proxy requests to a Hyperledger Indy-Node ledger")
         .arg(
             Arg::with_name("genesis")
                 .short("g")
                 .long("genesis")
+                .takes_value(true)
                 .value_name("GENESIS")
                 .help("Path to the ledger genesis transactions")
-                .takes_value(true),
         )
         .arg(
             Arg::with_name("host")
                 .short("h")
                 .long("host")
+                .takes_value(true)
                 .value_name("HOST")
                 .default_value("0.0.0.0")
                 .help("Set the local address to listen on")
-                .takes_value(true),
         )
         .arg(
             Arg::with_name("port")
                 .short("p")
                 .long("port")
+                .takes_value(true)
                 .value_name("PORT")
                 .help("Sets the local port to listen on")
-                .takes_value(true),
         )
         .arg(
             Arg::with_name("socket")
                 .short("s")
                 .long("socket")
+                .takes_value(true)
                 .value_name("SOCKET")
                 .help("Sets the UNIX socket path listen on")
-                .takes_value(true),
         )
         .arg(
             Arg::with_name("no-refresh")
                 .long("no-refresh")
                 .help("Disable initial validator node refresh"),
+        )
+        .arg(
+            Arg::with_name("refresh-interval")
+                .short("r")
+                .long("refresh-interval")
+                .takes_value(true)
+                .value_name("INTERVAL")
+                .help("Set the interval in minutes between validator node refresh attempts (0 to disable refresh, default 120)"),
         )
         .get_matches();
 
@@ -77,6 +85,11 @@ pub fn load_config() -> Result<Config, String> {
         None
     };
     let init_refresh = !matches.is_present("no-refresh");
+    let interval_refresh = matches
+        .value_of("refresh-interval")
+        .map(|ival| ival.parse::<u32>().map_err(|_| "Invalid refresh interval"))
+        .transpose()?
+        .unwrap_or(120);
 
     Ok(Config {
         genesis,
@@ -84,5 +97,6 @@ pub fn load_config() -> Result<Config, String> {
         host,
         port,
         init_refresh,
+        interval_refresh,
     })
 }

--- a/indy-vdr-proxy/src/handlers.rs
+++ b/indy-vdr-proxy/src/handlers.rs
@@ -5,7 +5,6 @@ use std::rc::Rc;
 use std::time::UNIX_EPOCH;
 
 use hyper::{Body, Method, Request, Response, StatusCode};
-use log::trace;
 use percent_encoding::percent_decode_str;
 
 use super::AppState;
@@ -18,100 +17,231 @@ use indy_vdr::pool::helpers::{perform_get_txn, perform_ledger_request};
 use indy_vdr::pool::{Pool, RequestResult, TimingResult};
 use indy_vdr::utils::qualifier::Qualifiable;
 
-fn format_request_result<T: std::fmt::Display>(
-    (result, timing): (RequestResult<T>, Option<TimingResult>),
-    pretty: bool,
-) -> VdrResult<(String, TimingResult)> {
-    match result {
-        RequestResult::Reply(message) => {
-            let message = message.to_string();
-            trace!("Got request response {} {:?}", &message, timing);
-            let message = if let Ok(mut json) = serde_json::from_str::<serde_json::Value>(&message)
-            {
-                let result = json["result"].as_object_mut();
-                if let Some(result) = result {
-                    if pretty {
-                        result.remove("identifier");
-                        result.remove("reqId");
-                        result.remove("state_proof");
-                        serde_json::to_string_pretty(&result).unwrap_or(message)
-                    } else {
-                        serde_json::to_string(&result).unwrap_or(message)
-                    }
-                } else {
-                    message
-                }
-            } else {
-                message
-            };
-            Ok((message, timing.unwrap()))
-        }
-        RequestResult::Failed(err) => {
-            trace!("No consensus {:?}", timing);
-            Err(err)
+#[derive(PartialEq, Eq)]
+enum ResponseFormat {
+    Html,
+    Raw,
+}
+
+enum ResponseType {
+    Genesis(String),
+    Json(String),
+    RequestReply(String, Option<TimingResult>),
+    RequestFailed(VdrError, Option<TimingResult>),
+    Status(StatusCode, String),
+}
+
+impl<T> From<(RequestResult<T>, Option<TimingResult>)> for ResponseType
+where
+    T: std::fmt::Display,
+{
+    fn from(result: (RequestResult<T>, Option<TimingResult>)) -> ResponseType {
+        match result {
+            (RequestResult::Reply(message), timing) => {
+                ResponseType::RequestReply(message.to_string(), timing)
+            }
+            (RequestResult::Failed(err), timing) => ResponseType::RequestFailed(err, timing),
         }
     }
 }
 
-fn format_result<T: std::fmt::Debug>(result: VdrResult<(String, T)>) -> VdrResult<String> {
-    Ok(match result {
-        Ok((msg, timing)) => format!("{}\n\n{:?}", msg, timing),
-        Err(err) => err.to_string(),
-    })
+impl From<VdrError> for ResponseType {
+    fn from(err: VdrError) -> ResponseType {
+        let (errcode, msg) = convert_error(err);
+        ResponseType::Status(errcode, msg)
+    }
 }
 
-fn format_ledger_error(err: VdrError) -> Result<Response<Body>, hyper::Error> {
+fn convert_error(err: VdrError) -> (StatusCode, String) {
     let msg = err.to_string();
-    let (errcode, msg) = match err.into() {
+    match err.into() {
         VdrErrorKind::PoolRequestFailed(failed) => (StatusCode::BAD_REQUEST, failed),
         VdrErrorKind::Input => (StatusCode::BAD_REQUEST, msg),
         VdrErrorKind::PoolTimeout => (StatusCode::GATEWAY_TIMEOUT, msg),
         VdrErrorKind::PoolNoConsensus => (StatusCode::CONFLICT, msg),
         // FIXME - UNAUTHORIZED error when BadRequest msg points to a missing signature
         _ => (StatusCode::INTERNAL_SERVER_ERROR, msg),
+    }
+}
+
+fn format_json_reply(message: String, pretty: bool) -> String {
+    if let Ok(mut json) = serde_json::from_str::<serde_json::Value>(&message) {
+        let result = json["result"].as_object_mut();
+        if let Some(result) = result {
+            if pretty {
+                result.remove("identifier");
+                result.remove("reqId");
+                result.remove("state_proof");
+                serde_json::to_string_pretty(&result).unwrap_or(message)
+            } else {
+                serde_json::to_string(&result).unwrap_or(message)
+            }
+        } else {
+            message
+        }
+    } else {
+        message
+    }
+}
+
+pub fn escape_html(val: &str) -> String {
+    val.replace("&", "&amp;").replace("<", "&lt;")
+}
+
+fn html_template(main: String, timing: Option<TimingResult>) -> String {
+    let main = main
+        .lines()
+        .map(|line| {
+            let mut ws = line.len();
+            let line = line.trim_start();
+            ws -= line.len();
+            format!(
+                "<div style=\"padding-left:{}ch;text-indent:-{}ch\">{}{}</div>\n",
+                ws + 2,
+                ws + 2,
+                "&nbsp;".repeat(ws),
+                escape_html(line)
+            )
+        })
+        .collect::<Vec<String>>()
+        .join("");
+
+    let timing = if let Some(timing) = timing {
+        format!(
+            "<div class=\"timing\"><div class=\"code\">{:?}</div></div>",
+            timing
+        )
+    } else {
+        "".to_owned()
     };
-    http_status_msg(errcode, msg)
+
+    format!(
+        r#"
+<html>
+    <head>
+        <meta charset="utf-8">
+        <title>Indy-VDR</title>
+        <style type="text/css">
+            .response::before, .timing::before {{
+                background: #eee;
+                border-radius: 4px 4px 0 0;
+                content: "Response";
+                display: block;
+                font-family: system-ui, sans-serif;
+                padding: 2px 0.5em;
+            }}
+            .timing::before {{
+                content: "Timing";
+            }}
+            .response, .timing {{
+                border: 1px solid #ddd;
+                border-radius: 5px;
+                margin: 1.5em 5%;
+            }}
+            .code {{
+                font-family: monospace;
+                font-size: 115%;
+                padding: 0.5em;
+                word-break: break-all;
+            }}
+        </style>
+    </head>
+    <body>
+        <div class="response">
+            <div class="code">{}</div>
+        </div>
+        {}
+    </body>
+</html>
+    "#,
+        main, timing
+    )
+}
+
+fn format_text(
+    result: String,
+    format: ResponseFormat,
+    status: StatusCode,
+    timing: Option<TimingResult>,
+) -> Response<Body> {
+    if format == ResponseFormat::Html {
+        Response::builder()
+            .status(status)
+            .header("Content-Type", "text/html")
+            .body(html_template(result, timing).into())
+            .unwrap()
+    } else {
+        Response::builder()
+            .status(status)
+            .header("Content-Type", "application/json")
+            .header(
+                "X-Requests",
+                if let Some(timing) = timing {
+                    format!("{:?}", timing)
+                } else {
+                    "".to_owned()
+                },
+            )
+            .body(result.into())
+            .unwrap()
+    }
+}
+
+fn format_result(
+    result: VdrResult<ResponseType>,
+    format: ResponseFormat,
+) -> Result<Response<Body>, hyper::Error> {
+    let result = match result {
+        Ok(result) => result,
+        Err(err) => err.into(),
+    };
+    let pretty = format == ResponseFormat::Html;
+    let response = match result {
+        ResponseType::Genesis(genesis) => format_text(genesis, format, StatusCode::OK, None),
+        ResponseType::Json(json) => {
+            let body = if pretty {
+                if let Ok(parsed) = serde_json::from_str::<serde_json::Value>(json.as_str()) {
+                    serde_json::to_string_pretty(&parsed).unwrap_or(json)
+                } else {
+                    json
+                }
+            } else {
+                json
+            };
+            format_text(body, format, StatusCode::OK, None)
+        }
+        ResponseType::RequestReply(reply, timing) => {
+            let reply = format_json_reply(reply, pretty);
+            format_text(reply, format, StatusCode::OK, timing)
+        }
+        ResponseType::RequestFailed(err, timing) => {
+            let (errcode, msg) = convert_error(err);
+            format_text(msg, format, errcode, timing)
+        }
+        ResponseType::Status(code, msg) => format_text(msg, format, code, None),
+    };
+    Ok(response)
 }
 
 fn timestamp_now() -> i64 {
     UNIX_EPOCH.elapsed().unwrap().as_secs() as i64
 }
-trait HandleVdrError {
-    fn make_response(self) -> Result<Response<Body>, hyper::Error>;
+
+fn http_status(code: StatusCode) -> VdrResult<ResponseType> {
+    http_status_msg(code, code.to_string())
 }
 
-impl<T> HandleVdrError for VdrResult<T>
-where
-    Body: From<T>,
+fn http_status_msg<T: std::fmt::Display>(code: StatusCode, msg: T) -> VdrResult<ResponseType> //Response<Body>, hyper::Error>
 {
-    fn make_response(self) -> Result<Response<Body>, hyper::Error> {
-        match self {
-            Err(err) => format_ledger_error(err),
-            Ok(msg) => Ok(Response::builder().body(Body::from(msg)).unwrap()),
-        }
-    }
+    Ok(ResponseType::Status(code, msg.to_string()))
 }
 
-fn http_status(code: StatusCode) -> Result<Response<Body>, hyper::Error> {
-    http_status_msg(code, "")
-}
-
-fn http_status_msg<M>(code: StatusCode, msg: M) -> Result<Response<Body>, hyper::Error>
-where
-    Body: From<M>,
-{
-    Ok(Response::builder()
-        .status(code)
-        .body(Body::from(msg))
-        .unwrap())
-}
-
-async fn get_pool_genesis<T: Pool>(pool: &T) -> VdrResult<String> {
+async fn get_pool_genesis<T: Pool>(pool: &T) -> VdrResult<ResponseType> {
     let txns = pool.get_transactions()?;
-    Ok(txns.join("\n"))
+    Ok(ResponseType::Genesis(txns.join("\n")))
 }
 
-fn format_pool_status(state: Rc<RefCell<AppState>>) -> VdrResult<String> {
+fn get_pool_status(state: Rc<RefCell<AppState>>) -> VdrResult<ResponseType> {
     let opt_pool = &state.borrow().pool;
     let (status, mt_root, mt_size, nodes) = if let Some(pool) = opt_pool {
         let (mt_root, mt_size) = pool.get_merkle_tree_root();
@@ -124,11 +254,12 @@ fn format_pool_status(state: Rc<RefCell<AppState>>) -> VdrResult<String> {
     let last_refresh = last_refresh.map(|tm| tm.elapsed().map(|d| d.as_secs()).ok());
 
     let result = json!({"status": status, "pool_mt_root": mt_root, "pool_mt_size": mt_size, "pool_nodes": nodes, "last_refresh": last_refresh});
-    Ok(serde_json::to_string(&result)
-        .with_err_msg(VdrErrorKind::Unexpected, "Error serializing JSON")?)
+    let result = serde_json::to_string(&result)
+        .with_err_msg(VdrErrorKind::Unexpected, "Error serializing JSON")?;
+    Ok(ResponseType::Json(result))
 }
 
-async fn get_attrib<T: Pool>(pool: &T, dest: &str, raw: &str, pretty: bool) -> VdrResult<String> {
+async fn get_attrib<T: Pool>(pool: &T, dest: &str, raw: &str) -> VdrResult<ResponseType> {
     let dest = DidValue::from_str(dest)?;
     let request = pool.get_request_builder().build_get_attrib_request(
         None,
@@ -138,54 +269,46 @@ async fn get_attrib<T: Pool>(pool: &T, dest: &str, raw: &str, pretty: bool) -> V
         None,
     )?;
     let result = perform_ledger_request(pool, request, None).await?;
-    format_result(format_request_result(result, pretty))
+    Ok(result.into())
 }
 
-async fn get_nym<T: Pool>(pool: &T, nym: &str, pretty: bool) -> VdrResult<String> {
+async fn get_nym<T: Pool>(pool: &T, nym: &str) -> VdrResult<ResponseType> {
     let nym = DidValue::from_str(nym)?;
     let request = pool
         .get_request_builder()
         .build_get_nym_request(None, &nym)?;
     let result = perform_ledger_request(pool, request, None).await?;
-    format_result(format_request_result(result, pretty))
+    Ok(result.into())
 }
 
-async fn get_schema<T: Pool>(pool: &T, schema_id: &str, pretty: bool) -> VdrResult<String> {
+async fn get_schema<T: Pool>(pool: &T, schema_id: &str) -> VdrResult<ResponseType> {
     let schema_id = SchemaId::from_str(schema_id)?;
     let request = pool
         .get_request_builder()
         .build_get_schema_request(None, &schema_id)?;
     let result = perform_ledger_request(pool, request, None).await?;
-    format_result(format_request_result(result, pretty))
+    Ok(result.into())
 }
 
-async fn get_cred_def<T: Pool>(pool: &T, cred_def_id: &str, pretty: bool) -> VdrResult<String> {
+async fn get_cred_def<T: Pool>(pool: &T, cred_def_id: &str) -> VdrResult<ResponseType> {
     let cred_def_id = CredentialDefinitionId::from_str(cred_def_id)?;
     let request = pool
         .get_request_builder()
         .build_get_cred_def_request(None, &cred_def_id)?;
     let result = perform_ledger_request(pool, request, None).await?;
-    format_result(format_request_result(result, pretty))
+    Ok(result.into())
 }
 
-async fn get_revoc_reg_def<T: Pool>(
-    pool: &T,
-    revoc_reg_def_id: &str,
-    pretty: bool,
-) -> VdrResult<String> {
+async fn get_revoc_reg_def<T: Pool>(pool: &T, revoc_reg_def_id: &str) -> VdrResult<ResponseType> {
     let revoc_reg_def_id = RevocationRegistryId::from_str(revoc_reg_def_id)?;
     let request = pool
         .get_request_builder()
         .build_get_revoc_reg_def_request(None, &revoc_reg_def_id)?;
     let result = perform_ledger_request(pool, request, None).await?;
-    format_result(format_request_result(result, pretty))
+    Ok(result.into())
 }
 
-async fn get_revoc_reg<T: Pool>(
-    pool: &T,
-    revoc_reg_def_id: &str,
-    pretty: bool,
-) -> VdrResult<String> {
+async fn get_revoc_reg<T: Pool>(pool: &T, revoc_reg_def_id: &str) -> VdrResult<ResponseType> {
     let revoc_reg_def_id = RevocationRegistryId::from_str(revoc_reg_def_id)?;
     let request = pool.get_request_builder().build_get_revoc_reg_request(
         None,
@@ -193,20 +316,16 @@ async fn get_revoc_reg<T: Pool>(
         timestamp_now(),
     )?;
     let result = perform_ledger_request(pool, request, None).await?;
-    format_result(format_request_result(result, pretty))
+    Ok(result.into())
 }
 
-async fn get_revoc_reg_delta<T: Pool>(
-    pool: &T,
-    revoc_reg_def_id: &str,
-    pretty: bool,
-) -> VdrResult<String> {
+async fn get_revoc_reg_delta<T: Pool>(pool: &T, revoc_reg_def_id: &str) -> VdrResult<ResponseType> {
     let revoc_reg_def_id = RevocationRegistryId::from_str(revoc_reg_def_id)?;
     let request = pool
         .get_request_builder()
         .build_get_revoc_reg_delta_request(None, &revoc_reg_def_id, None, timestamp_now())?;
     let result = perform_ledger_request(pool, request, None).await?;
-    format_result(format_request_result(result, pretty))
+    Ok(result.into())
 }
 
 /*
@@ -216,20 +335,20 @@ async fn test_get_validator_info<T: Pool>(pool: &T, pretty: bool) -> VdrResult<S
 }
 */
 
-async fn get_taa<T: Pool>(pool: &T, pretty: bool) -> VdrResult<String> {
+async fn get_taa<T: Pool>(pool: &T) -> VdrResult<ResponseType> {
     let request = pool
         .get_request_builder()
         .build_get_txn_author_agreement_request(None, None)?;
     let result = perform_ledger_request(pool, request, None).await?;
-    format_result(format_request_result(result, pretty))
+    Ok(result.into())
 }
 
-async fn get_aml<T: Pool>(pool: &T, pretty: bool) -> VdrResult<String> {
+async fn get_aml<T: Pool>(pool: &T) -> VdrResult<ResponseType> {
     let request = pool
         .get_request_builder()
         .build_get_acceptance_mechanisms_request(None, None, None)?;
     let result = perform_ledger_request(pool, request, None).await?;
-    format_result(format_request_result(result, pretty))
+    Ok(result.into())
 }
 
 async fn get_auth_rule<T: Pool>(
@@ -237,8 +356,7 @@ async fn get_auth_rule<T: Pool>(
     auth_type: Option<String>,
     auth_action: Option<String>,
     field: Option<String>,
-    pretty: bool,
-) -> VdrResult<String> {
+) -> VdrResult<ResponseType> {
     let request = pool.get_request_builder().build_get_auth_rule_request(
         None,
         auth_type,
@@ -248,25 +366,20 @@ async fn get_auth_rule<T: Pool>(
         None,
     )?;
     let result = perform_ledger_request(pool, request, None).await?;
-    format_result(format_request_result(result, pretty))
+    Ok(result.into())
 }
 
-async fn get_txn<T: Pool>(pool: &T, ledger: i32, seq_no: i32, pretty: bool) -> VdrResult<String> {
+async fn get_txn<T: Pool>(pool: &T, ledger: i32, seq_no: i32) -> VdrResult<ResponseType> {
     let result = perform_get_txn(pool, ledger, seq_no).await?;
-    format_result(format_request_result(result, pretty))
+    Ok(result.into())
 }
 
-async fn submit_request<T: Pool>(
-    pool: &T,
-    message: Vec<u8>,
-    pretty: bool,
-) -> VdrResult<(String, String)> {
+async fn submit_request<T: Pool>(pool: &T, message: Vec<u8>) -> VdrResult<ResponseType> {
     let (request, target) =
         pool.get_request_builder()
             .build_custom_request(&message, None, (None, None))?;
     let result = perform_ledger_request(pool, request, target).await?;
-    let (response, timing) = format_request_result(result, pretty)?;
-    Ok((response, format!("{:?}", timing)))
+    Ok(result.into())
 }
 
 pub async fn handle_request<T: Pool>(
@@ -284,49 +397,62 @@ pub async fn handle_request<T: Pool>(
                 .ok()
                 .filter(|p| !p.is_empty())
         });
-    let pretty = req.uri().query() == Some("fmt");
+    let query = req.uri().query();
+    let format = if query == Some("html") {
+        ResponseFormat::Html
+    } else if query == Some("raw") {
+        ResponseFormat::Raw
+    } else {
+        if let Some(Ok(accept)) = req.headers().get("accept").map(|h| h.to_str()) {
+            let accept = accept.to_ascii_lowercase();
+            let html_pos = accept.find("text/html");
+            let json_pos = accept.find("/json");
+            match (html_pos, json_pos) {
+                (Some(h), Some(j)) => {
+                    if h < j {
+                        ResponseFormat::Html
+                    } else {
+                        ResponseFormat::Raw
+                    }
+                }
+                (Some(_), None) => ResponseFormat::Html,
+                _ => ResponseFormat::Raw,
+            }
+        } else {
+            ResponseFormat::Raw
+        }
+    };
     let fst = parts.next().unwrap_or_else(|| "".to_owned());
     let req_method = req.method();
     if (req_method, fst.is_empty()) == (&Method::GET, true) {
-        return format_pool_status(state.clone()).make_response();
+        return format_result(get_pool_status(state.clone()), format);
     }
     let opt_pool = &state.borrow().pool;
     let pool = match opt_pool {
         None => {
-            return http_status(StatusCode::SERVICE_UNAVAILABLE);
+            return format_result(http_status(StatusCode::SERVICE_UNAVAILABLE), format);
         }
         Some(pool) => pool,
     };
-    match (req_method, fst.as_str()) {
+    let result = match (req_method, fst.as_str()) {
         // (&Method::GET, "status") => test_get_validator_info(pool, pretty).await.make_response(),
         (&Method::GET, "submit") => http_status(StatusCode::METHOD_NOT_ALLOWED),
         (&Method::POST, "submit") => {
             let body_bytes = hyper::body::to_bytes(req.into_body()).await?;
             let body = body_bytes.iter().cloned().collect::<Vec<u8>>();
             if !body.is_empty() {
-                match submit_request(pool, body, pretty).await {
-                    Ok((result, timing)) => {
-                        let mut response = Response::new(Body::from(result));
-                        response
-                            .headers_mut()
-                            .append("X-Requests", timing.parse().unwrap());
-                        Ok(response)
-                    }
-                    Err(err) => format_ledger_error(err),
-                }
+                submit_request(pool, body).await
             } else {
                 http_status(StatusCode::BAD_REQUEST)
             }
         }
-        (&Method::GET, "genesis") => get_pool_genesis(pool).await.make_response(),
-        (&Method::GET, "taa") => get_taa(pool, pretty).await.make_response(),
-        (&Method::GET, "aml") => get_aml(pool, pretty).await.make_response(),
+        (&Method::GET, "genesis") => get_pool_genesis(pool).await,
+        (&Method::GET, "taa") => get_taa(pool).await,
+        (&Method::GET, "aml") => get_aml(pool).await,
         (&Method::GET, "attrib") => {
             if let (Some(dest), Some(attrib)) = (parts.next(), parts.next()) {
                 // NOTE: 'endpoint' is currently the only supported attribute
-                get_attrib(pool, &*dest, &*attrib, pretty)
-                    .await
-                    .make_response()
+                get_attrib(pool, &*dest, &*attrib).await
             } else {
                 http_status(StatusCode::NOT_FOUND)
             }
@@ -339,65 +465,53 @@ pub async fn handle_request<T: Pool>(
                         Some(auth_type.to_owned()),
                         Some(auth_action.to_owned()),
                         Some("*".to_owned()),
-                        pretty,
                     )
                     .await
-                    .make_response()
                 } else {
                     http_status(StatusCode::NOT_FOUND)
                 }
             } else {
-                get_auth_rule(pool, None, None, None, pretty)
-                    .await
-                    .make_response() // get all
+                get_auth_rule(pool, None, None, None).await // get all
             }
         }
         (&Method::GET, "cred_def") => {
             if let Some(cred_def_id) = parts.next() {
-                get_cred_def(pool, &*cred_def_id, pretty)
-                    .await
-                    .make_response()
+                get_cred_def(pool, &*cred_def_id).await
             } else {
                 http_status(StatusCode::NOT_FOUND)
             }
         }
         (&Method::GET, "nym") => {
             if let Some(nym) = parts.next() {
-                get_nym(pool, &*nym, pretty).await.make_response()
+                get_nym(pool, &*nym).await
             } else {
                 http_status(StatusCode::NOT_FOUND)
             }
         }
         (&Method::GET, "rev_reg_def") => {
             if let Some(rev_reg_def_id) = parts.next() {
-                get_revoc_reg_def(pool, &*rev_reg_def_id, pretty)
-                    .await
-                    .make_response()
+                get_revoc_reg_def(pool, &*rev_reg_def_id).await
             } else {
                 http_status(StatusCode::NOT_FOUND)
             }
         }
         (&Method::GET, "rev_reg") => {
             if let Some(rev_reg_def_id) = parts.next() {
-                get_revoc_reg(pool, &*rev_reg_def_id, pretty)
-                    .await
-                    .make_response()
+                get_revoc_reg(pool, &*rev_reg_def_id).await
             } else {
                 http_status(StatusCode::NOT_FOUND)
             }
         }
         (&Method::GET, "rev_reg_delta") => {
             if let Some(rev_reg_def_id) = parts.next() {
-                get_revoc_reg_delta(pool, &*rev_reg_def_id, pretty)
-                    .await
-                    .make_response()
+                get_revoc_reg_delta(pool, &*rev_reg_def_id).await
             } else {
                 http_status(StatusCode::NOT_FOUND)
             }
         }
         (&Method::GET, "schema") => {
             if let Some(schema_id) = parts.next() {
-                get_schema(pool, &*schema_id, pretty).await.make_response()
+                get_schema(pool, &*schema_id).await
             } else {
                 http_status(StatusCode::NOT_FOUND)
             }
@@ -405,12 +519,16 @@ pub async fn handle_request<T: Pool>(
         (&Method::GET, "txn") => {
             if let (Some(ledger), Some(txn)) = (parts.next(), parts.next()) {
                 if let (Ok(ledger), Ok(txn)) = (ledger.parse::<i32>(), txn.parse::<i32>()) {
-                    return get_txn(pool, ledger, txn, pretty).await.make_response();
+                    get_txn(pool, ledger, txn).await
+                } else {
+                    http_status(StatusCode::NOT_FOUND)
                 }
+            } else {
+                http_status(StatusCode::NOT_FOUND)
             }
-            http_status(StatusCode::NOT_FOUND)
         }
         (&Method::GET, _) => http_status(StatusCode::NOT_FOUND),
         _ => http_status(StatusCode::METHOD_NOT_ALLOWED),
-    }
+    };
+    format_result(result, format)
 }


### PR DESCRIPTION
- Output HTML when text/html is requested or `?html` query string is used, otherwise output application/json and return timing information as a header (fixes #16)
- Add auto-refresh of validator pool. New `--refresh-interval` option, defaults to 120 minutes (fixes #17)