### PR TITLE
Import sha3 directly instead of through ursa

### DIFF
--- a/libindy_vdr/Cargo.toml
+++ b/libindy_vdr/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "indy-vdr"
-version = "0.3.2"
+version = "0.3.3"
 authors = ["Hyperledger Indy Contributors <hyperledger-indy@lists.hyperledger.org>"]
 description = "A library for interacting with Hyperledger Indy Node, a distributed ledger for self-sovereign identity (https://www.hyperledger.org/use/hyperledger-indy)."
 edition = "2018"
@@ -41,13 +41,14 @@ regex = "1.3"
 rmp-serde = "0.13.7"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+sha3 = "0.9"
 thiserror = "1.0.9"
 zmq = "0.9.2"
 
 [dependencies.ursa]
 version = "0.3.5"
 default-features = false
-features = ["bls_bn254", "sha3"]
+features = ["bls_bn254"]
 
 [dev-dependencies]
 rstest = "0.6"

--- a/libindy_vdr/src/pool/types.rs
+++ b/libindy_vdr/src/pool/types.rs
@@ -513,8 +513,8 @@ pub struct SimpleRequest {
     pub req_id: u64,
 }
 
-#[serde(tag = "op")]
 #[derive(Serialize, Deserialize, Debug)]
+#[serde(tag = "op")]
 pub enum Message {
     #[serde(rename = "CONSISTENCY_PROOF")]
     ConsistencyProof(ConsistencyProof),

--- a/wrappers/python/indy_vdr/version.py
+++ b/wrappers/python/indy_vdr/version.py
@@ -1,3 +1,3 @@
 """indy_vdr library wrapper version."""
 
-__version__ = "0.3.2"
+__version__ = "0.3.3"


### PR DESCRIPTION
Ursa 0.3.7 was released with a different and incompatible version of the dependency, so this fixes a build error as well.