### PR TITLE
Feature/general indy resolver

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [main]
   pull_request:
-    branches: [main]
+    branches: [main, did-indy]
   release:
     types: [created]
   workflow_dispatch:

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ node_modules
 Podfile.lock
 .vscode
 coverage
+github

--- a/README.md
+++ b/README.md
@@ -39,26 +39,41 @@ At a later stage it should be possible to install a precompiled 'wheel' package 
 
 ## Proxy Server
 
-The `indy-vdr-proxy` executable can be used to provide a simple REST API for interacting with the ledger. Command line options can be inspected by running `indy-vdr-proxy --help`.
+The `indy-vdr-proxy` executable can be used to provide a simple REST API for interacting with one or more Indy ledgers. Command line options can be inspected by running `indy-vdr-proxy --help`.
+
+To start the proxy server with the standard configuration of indy ledgers use the following command:
+`indy-vdr-proxy -p <PORT> -r <POOL_REFRESH_INTERVAL_IN_MIN>`
+This will get the ledger configuration from `https://github.com/IDunion/indy-did-networks`
+
+A custom ledger configuration can be provided either by specificing a Github repo or a local folder:
+`indy-vdr-proxy -p <PORT> -l <GITHUB_URL or PATH_TO_FOLDER>`
+The structure needs to be as follows `<NAMESPACE>/OPTIONAL<SUB_NAMESPACE>/pool_transactions_genesis.json`, e.g. `/sovrin/staging/pool_transactions_genesis.json`
 
 Responses can be formatted in either HTML or JSON formats. HTML formatting is selected when the `text/html` content type is requested according to the Accept header (as sent by web browsers) or the request query string is set to `?html`. JSON formatting is selected otherwise, and may be explitly selected by using the query string `?raw`. For most ledger requests, JSON responses include information regarding which nodes were contacted is returned in the `X-Requests` header.
 
 Sending prepared requests to the ledger is performed by delivering a POST request to the `/submit` endpoint, where the body of the request is the JSON-formatted payload. Additional endpoints are provided as shortcuts for ledger read transactions:
 
-- `/` The root path shows basic status information about the server and the ledger pool
-- `/genesis` Return the current set of genesis transactions
-- `/taa` Fetch the current ledger Transaction Author Agreement
-- `/aml` Fetch the current ledger Acceptance Methods List (for the TAA)
-- `/nym/{DID}` Fetch the NYM transaction associated with a DID
-- `/attrib/{DID}/endpoint` Fetch the registered endpoint for a DID
-- `/schema/{SCHEMA_ID}` Fetch a schema by its identifier
-- `/cred_def/{CRED_DEF_ID}` Fetch a credential definition by its identifier
-- `/rev_reg/{REV_REG_ID}` Fetch a revocation registry by its identifier
-- `/rev_reg_def/{REV_REG_ID}` Fetch a revocation registry definition by its registry identifier
-- `/rev_reg_delta/{REV_REG_ID}` Fetch a revocation registry delta by its registry identifier
-- `/auth` Fetch all AUTH rules for the ledger
-- `/auth/{TXN_TYPE}/{ADD|EDIT}` Fetch the AUTH rule for a specific transaction type and action
-- `/txn/{SUBLEDGER}/{SEQ_NO}` Fetch a specific transaction by subledger identifier (0-2, or one of `pool`, `domain`, or `config`) and sequence number.
+- `/` Lists the configured ledgers
+- `{LEDGER}/` The root path shows basic status information about the server and the ledger pool
+- `{LEDGER}/genesis` Return the current set of genesis transactions
+- `{LEDGER}/taa` Fetch the current ledger Transaction Author Agreement
+- `{LEDGER}/aml` Fetch the current ledger Acceptance Methods List (for the TAA)
+- `{LEDGER}/nym/{DID}` Fetch the NYM transaction associated with a DID
+- `{LEDGER}/attrib/{DID}/endpoint` Fetch the registered endpoint for a DID
+- `{LEDGER}/schema/{SCHEMA_ID}` Fetch a schema by its identifier
+- `{LEDGER}/cred_def/{CRED_DEF_ID}` Fetch a credential definition by its identifier
+- `{LEDGER}/rev_reg/{REV_REG_ID}` Fetch a revocation registry by its identifier
+- `{LEDGER}/rev_reg_def/{REV_REG_ID}` Fetch a revocation registry definition by its registry identifier
+- `{LEDGER}/rev_reg_delta/{REV_REG_ID}` Fetch a revocation registry delta by its registry identifier
+- `{LEDGER}/auth` Fetch all AUTH rules for the ledger
+- `{LEDGER}/auth/{TXN_TYPE}/{ADD|EDIT}` Fetch the AUTH rule for a specific transaction type and action
+- `{LEDGER}/txn/{SUBLEDGER}/{SEQ_NO}` Fetch a specific transaction by subledger identifier (0-2, or one of `pool`, `domain`, or `config`) and sequence number.
+
+### DID:Indy Resolver
+
+Indy VDR contains a DID Resolver to resolve DIDs and dereference DID Urls to ledger objects according to the [did:indy specification](https://hyperledger.github.io/indy-did-method/).
+
+`GET /1.0/identifiers/{DID or DID_URL}`
 
 ## Connecting to a Ledger
 

--- a/indy-vdr-proxy/Cargo.toml
+++ b/indy-vdr-proxy/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "indy-vdr-proxy"
-version = "0.1.2"
+version = "0.2.0"
 authors = ["Hyperledger Indy Contributors <hyperledger-indy@lists.hyperledger.org>"]
 description = "A basic proxy server exposing indy-vdr functionality over an HTTP interface"
 edition = "2021"
@@ -20,6 +20,7 @@ hyper = { version = "0.14", features = ["http1", "http2", "server"] }
 hyper-tls = { version = "0.5", optional = true }
 log = "0.4.8"
 percent-encoding = "2"
+regex = "1.5.4"
 serde_json = "1.0"
 tokio = { version = "1.0", features = ["macros", "rt-multi-thread", "signal"] }
 url = "2.2.2"

--- a/indy-vdr-proxy/Cargo.toml
+++ b/indy-vdr-proxy/Cargo.toml
@@ -15,7 +15,7 @@ default = ["fetch", "zmq_vendored"]
 clap = "3.1"
 env_logger = "0.9"
 futures-util = "0.3"
-indy-vdr = { version = "0.4", path = "../libindy_vdr", default-features = false, features = ["log"] }
+indy-vdr = { version = "0.4", path = "../libindy_vdr", default-features = false, features = ["log", "git"] }
 hyper = { version = "0.14", features = ["http1", "http2", "server"] }
 hyper-tls = { version = "0.5", optional = true }
 log = "0.4.8"

--- a/indy-vdr-proxy/src/app.rs
+++ b/indy-vdr-proxy/src/app.rs
@@ -2,7 +2,7 @@ extern crate clap;
 use clap::{Arg, Command};
 
 pub struct Config {
-    pub genesis: Option<String>,
+    pub ledgers: Option<String>,
     #[cfg(unix)]
     pub socket: Option<String>,
     pub host: Option<String>,
@@ -17,12 +17,12 @@ pub fn load_config() -> Result<Config, String> {
         .version("0.2.0")
         .about("Proxy requests to a Hyperledger Indy-Node ledger")
         .arg(
-            Arg::new("genesis")
-                .short('g')
-                .long("genesis")
+            Arg::new("ledgers")
+                .short('l')
+                .long("ledgers")
                 .takes_value(true)
-                .value_name("GENESIS")
-                .help("Path to the ledger genesis transactions")
+                .value_name("LEDGERS")
+                .help("Path to Indy networks Github repo or local folder")
         )
         .arg(
             Arg::new("host")
@@ -68,7 +68,7 @@ pub fn load_config() -> Result<Config, String> {
 
     let matches = app.get_matches();
 
-    let genesis = matches.value_of("genesis").map(str::to_owned);
+    let ledgers = matches.value_of("ledgers").map(str::to_owned);
 
     if matches.occurrences_of("socket") > 0 {
         if matches.occurrences_of("host") > 0 {
@@ -97,7 +97,7 @@ pub fn load_config() -> Result<Config, String> {
         .unwrap_or(120);
 
     Ok(Config {
-        genesis,
+        ledgers,
         #[cfg(unix)]
         socket,
         host,

--- a/indy-vdr-proxy/src/app.rs
+++ b/indy-vdr-proxy/src/app.rs
@@ -2,7 +2,7 @@ extern crate clap;
 use clap::{Arg, Command};
 
 pub struct Config {
-    pub genesis: String,
+    pub genesis: Option<String>,
     #[cfg(unix)]
     pub socket: Option<String>,
     pub host: Option<String>,
@@ -14,7 +14,7 @@ pub struct Config {
 pub fn load_config() -> Result<Config, String> {
     #[allow(unused_mut)]
     let mut app = Command::new("indy-vdr-proxy")
-        .version("0.1.0")
+        .version("0.2.0")
         .about("Proxy requests to a Hyperledger Indy-Node ledger")
         .arg(
             Arg::new("genesis")
@@ -68,10 +68,7 @@ pub fn load_config() -> Result<Config, String> {
 
     let matches = app.get_matches();
 
-    let genesis = matches
-        .value_of("genesis")
-        .unwrap_or("genesis.txn")
-        .to_owned();
+    let genesis = matches.value_of("genesis").map(str::to_owned);
 
     if matches.occurrences_of("socket") > 0 {
         if matches.occurrences_of("host") > 0 {

--- a/indy-vdr-proxy/src/handlers.rs
+++ b/indy-vdr-proxy/src/handlers.rs
@@ -8,6 +8,7 @@ use std::time::UNIX_EPOCH;
 
 use hyper::{Body, Method, Request, Response, StatusCode};
 use percent_encoding::percent_decode_str;
+use regex::Regex;
 
 use super::AppState;
 use indy_vdr::common::error::prelude::*;
@@ -29,6 +30,7 @@ enum ResponseType {
     RequestReply(String, Option<TimingResult>),
     RequestFailed(VdrError, Option<TimingResult>),
     Status(StatusCode, String),
+    Resolver(String),
 }
 
 impl<T> From<(RequestResult<T>, Option<TimingResult>)> for ResponseType
@@ -219,6 +221,10 @@ fn format_result(
             format_text(msg, format, errcode, timing)
         }
         ResponseType::Status(code, msg) => format_text(msg, format, code, None),
+        ResponseType::Resolver(reply) => {
+            let reply = format_json_reply(reply, pretty);
+            format_text(reply, format, StatusCode::OK, None)
+        }
     };
     Ok(response)
 }
@@ -241,15 +247,11 @@ async fn get_pool_genesis<T: Pool>(pool: &T) -> VdrResult<ResponseType> {
     Ok(ResponseType::Genesis(txns.join("\n")))
 }
 
-fn get_pool_status(state: Rc<RefCell<AppState>>) -> VdrResult<ResponseType> {
-    let opt_pool = &state.borrow().pool;
-    let (status, mt_root, mt_size, nodes) = if let Some(pool) = opt_pool {
-        let (mt_root, mt_size) = pool.get_merkle_tree_info();
-        let nodes = pool.get_node_aliases();
-        ("active", Some(mt_root), Some(mt_size), Some(nodes))
-    } else {
-        ("init", None, None, None)
-    };
+fn get_pool_status<T: Pool>(pool: &T, state: Rc<RefCell<AppState>>) -> VdrResult<ResponseType> {
+    let status = "active";
+    let (mt_root, mt_size) = pool.get_merkle_tree_info();
+    let nodes = pool.get_node_aliases();
+
     let last_refresh = &state.borrow().last_refresh;
     let last_refresh = last_refresh.map(|tm| tm.elapsed().map(|d| d.as_secs()).ok());
 
@@ -434,121 +436,157 @@ pub async fn handle_request<T: Pool>(
             ResponseFormat::Raw
         }
     };
+    let namespace = parts.next().unwrap_or_else(|| "".to_owned());
     let fst = parts.next().unwrap_or_else(|| "".to_owned());
     let req_method = req.method();
-    if (req_method, fst.is_empty()) == (&Method::GET, true) {
-        return format_result(get_pool_status(state.clone()), format);
-    }
-    let opt_pool = &state.borrow().pool;
-    let pool = match opt_pool {
-        None => {
-            return format_result(http_status(StatusCode::SERVICE_UNAVAILABLE), format);
-        }
-        Some(pool) => pool,
+    let state_cp = state.borrow();
+    let pool = state_cp.vdr.get_pool(&namespace);
+
+    let resolver_regex = Regex::new("/1.0/identifiers/(.*)").unwrap();
+
+    let captures = resolver_regex.captures(req.uri().path());
+    let did = if let Some(cap) = captures {
+        Some(cap.get(1).unwrap().as_str())
+    } else {
+        None
     };
-    let result = match (req_method, fst.as_str()) {
-        // (&Method::GET, "status") => test_get_validator_info(pool, pretty).await.make_response(),
-        (&Method::GET, "submit") => http_status(StatusCode::METHOD_NOT_ALLOWED),
-        (&Method::POST, "submit") => {
-            let body_bytes = hyper::body::to_bytes(req.into_body()).await?;
-            let body = body_bytes.iter().cloned().collect::<Vec<u8>>();
-            if !body.is_empty() {
-                submit_request(pool, body).await
-            } else {
-                http_status(StatusCode::BAD_REQUEST)
+
+    // use DID Resolution/Dereference
+    let result = if did.is_some() {
+        let did = did.unwrap();
+        // is   DID Url
+        if did.find("/").is_some() {
+            match state_cp.vdr.dereference(did).await {
+                Ok(result) => Ok(ResponseType::Resolver(result)),
+                Err(err) => http_status_msg(StatusCode::BAD_REQUEST, err.to_string()),
+            }
+        } else {
+            match state_cp.vdr.resolve(did).await {
+                Ok(result) => Ok(ResponseType::Resolver(result)),
+                Err(err) => http_status_msg(StatusCode::BAD_REQUEST, err.to_string()),
             }
         }
-        (&Method::GET, "genesis") => get_pool_genesis(pool).await,
-        (&Method::GET, "taa") => get_taa(pool).await,
-        (&Method::GET, "aml") => get_aml(pool).await,
-        (&Method::GET, "attrib") => {
-            if let (Some(dest), Some(attrib)) = (parts.next(), parts.next()) {
-                // NOTE: 'endpoint' is currently the only supported attribute
-                get_attrib(pool, &*dest, &*attrib).await
-            } else {
-                http_status(StatusCode::NOT_FOUND)
+    } else {
+        if namespace == "" {
+            return format_result(
+                Ok(ResponseType::Resolver(
+                    state_cp.vdr.get_ledgers().unwrap().join("\n"),
+                )),
+                format,
+            );
+        } else if pool.is_none() {
+            http_status_msg(StatusCode::NOT_FOUND, "Ledger not configured")
+        } else {
+            let pool = pool.unwrap();
+            if (req_method, fst.is_empty()) == (&Method::GET, true) {
+                return format_result(get_pool_status(pool, state.clone()), format);
             }
-        }
-        (&Method::GET, "auth") => {
-            if let Some(auth_type) = parts.next() {
-                if let Some(auth_action) = parts.next() {
-                    get_auth_rule(
-                        pool,
-                        Some(auth_type.to_owned()),
-                        Some(auth_action.to_owned()),
-                        Some("*".to_owned()),
-                    )
-                    .await
-                } else {
-                    http_status(StatusCode::NOT_FOUND)
+            match (req_method, fst.as_str()) {
+                // (&Method::GET, "status") => test_get_validator_info(pool, pretty).await.make_response(),
+                (&Method::GET, "submit") => http_status(StatusCode::METHOD_NOT_ALLOWED),
+                (&Method::POST, "submit") => {
+                    let body_bytes = hyper::body::to_bytes(req.into_body()).await?;
+                    let body = body_bytes.iter().cloned().collect::<Vec<u8>>();
+                    if !body.is_empty() {
+                        submit_request(pool, body).await
+                    } else {
+                        http_status(StatusCode::BAD_REQUEST)
+                    }
                 }
-            } else {
-                get_auth_rule(pool, None, None, None).await // get all
-            }
-        }
-        (&Method::GET, "cred_def") => {
-            if let Some(cred_def_id) = parts.next() {
-                get_cred_def(pool, &*cred_def_id).await
-            } else {
-                http_status(StatusCode::NOT_FOUND)
-            }
-        }
-        (&Method::GET, "nym") => {
-            if let Some(nym) = parts.next() {
-                let seq_no: Option<i32> = query_params
-                    .get("seq_no")
-                    .and_then(|seq_no| seq_no.as_str().parse().ok());
-                let timestamp: Option<u64> = query_params
-                    .get("timestamp")
-                    .and_then(|ts| ts.as_str().parse().ok());
-                get_nym(pool, &*nym, seq_no, timestamp).await
-            } else {
-                http_status(StatusCode::NOT_FOUND)
-            }
-        }
-        (&Method::GET, "rev_reg_def") => {
-            if let Some(rev_reg_def_id) = parts.next() {
-                get_revoc_reg_def(pool, &*rev_reg_def_id).await
-            } else {
-                http_status(StatusCode::NOT_FOUND)
-            }
-        }
-        (&Method::GET, "rev_reg") => {
-            if let Some(rev_reg_def_id) = parts.next() {
-                get_revoc_reg(pool, &*rev_reg_def_id).await
-            } else {
-                http_status(StatusCode::NOT_FOUND)
-            }
-        }
-        (&Method::GET, "rev_reg_delta") => {
-            if let Some(rev_reg_def_id) = parts.next() {
-                get_revoc_reg_delta(pool, &*rev_reg_def_id).await
-            } else {
-                http_status(StatusCode::NOT_FOUND)
-            }
-        }
-        (&Method::GET, "schema") => {
-            if let Some(schema_id) = parts.next() {
-                get_schema(pool, &*schema_id).await
-            } else {
-                http_status(StatusCode::NOT_FOUND)
-            }
-        }
-        (&Method::GET, "txn") => {
-            if let (Some(ledger), Some(txn)) = (parts.next(), parts.next()) {
-                if let (Ok(ledger), Ok(txn)) =
-                    (LedgerType::try_from(ledger.as_str()), txn.parse::<i32>())
-                {
-                    get_txn(pool, ledger, txn).await
-                } else {
-                    http_status(StatusCode::NOT_FOUND)
+                (&Method::GET, "genesis") => get_pool_genesis(pool).await,
+                (&Method::GET, "taa") => get_taa(pool).await,
+                (&Method::GET, "aml") => get_aml(pool).await,
+                (&Method::GET, "attrib") => {
+                    if let (Some(dest), Some(attrib)) = (parts.next(), parts.next()) {
+                        // NOTE: 'endpoint' is currently the only supported attribute
+                        get_attrib(pool, &*dest, &*attrib).await
+                    } else {
+                        http_status(StatusCode::NOT_FOUND)
+                    }
                 }
-            } else {
-                http_status(StatusCode::NOT_FOUND)
+                (&Method::GET, "auth") => {
+                    if let Some(auth_type) = parts.next() {
+                        if let Some(auth_action) = parts.next() {
+                            get_auth_rule(
+                                pool,
+                                Some(auth_type.to_owned()),
+                                Some(auth_action.to_owned()),
+                                Some("*".to_owned()),
+                            )
+                            .await
+                        } else {
+                            http_status(StatusCode::NOT_FOUND)
+                        }
+                    } else {
+                        get_auth_rule(pool, None, None, None).await // get all
+                    }
+                }
+                (&Method::GET, "cred_def") => {
+                    if let Some(cred_def_id) = parts.next() {
+                        get_cred_def(pool, &*cred_def_id).await
+                    } else {
+                        http_status(StatusCode::NOT_FOUND)
+                    }
+                }
+                (&Method::GET, "nym") => {
+                    if let Some(nym) = parts.next() {
+                        let seq_no: Option<i32> = query_params
+                            .get("seq_no")
+                            .and_then(|seq_no| seq_no.as_str().parse().ok());
+                        let timestamp: Option<u64> = query_params
+                            .get("timestamp")
+                            .and_then(|ts| ts.as_str().parse().ok());
+                        get_nym(pool, &*nym, seq_no, timestamp).await
+                    } else {
+                        http_status(StatusCode::NOT_FOUND)
+                    }
+                }
+                (&Method::GET, "rev_reg_def") => {
+                    if let Some(rev_reg_def_id) = parts.next() {
+                        get_revoc_reg_def(pool, &*rev_reg_def_id).await
+                    } else {
+                        http_status(StatusCode::NOT_FOUND)
+                    }
+                }
+                (&Method::GET, "rev_reg") => {
+                    if let Some(rev_reg_def_id) = parts.next() {
+                        get_revoc_reg(pool, &*rev_reg_def_id).await
+                    } else {
+                        http_status(StatusCode::NOT_FOUND)
+                    }
+                }
+                (&Method::GET, "rev_reg_delta") => {
+                    if let Some(rev_reg_def_id) = parts.next() {
+                        get_revoc_reg_delta(pool, &*rev_reg_def_id).await
+                    } else {
+                        http_status(StatusCode::NOT_FOUND)
+                    }
+                }
+                (&Method::GET, "schema") => {
+                    if let Some(schema_id) = parts.next() {
+                        get_schema(pool, &*schema_id).await
+                    } else {
+                        http_status(StatusCode::NOT_FOUND)
+                    }
+                }
+                (&Method::GET, "txn") => {
+                    if let (Some(ledger), Some(txn)) = (parts.next(), parts.next()) {
+                        if let (Ok(ledger), Ok(txn)) =
+                            (LedgerType::try_from(ledger.as_str()), txn.parse::<i32>())
+                        {
+                            get_txn(pool, ledger, txn).await
+                        } else {
+                            http_status(StatusCode::NOT_FOUND)
+                        }
+                    } else {
+                        http_status(StatusCode::NOT_FOUND)
+                    }
+                }
+                (&Method::GET, _) => http_status(StatusCode::NOT_FOUND),
+                _ => http_status(StatusCode::METHOD_NOT_ALLOWED),
             }
         }
-        (&Method::GET, _) => http_status(StatusCode::NOT_FOUND),
-        _ => http_status(StatusCode::METHOD_NOT_ALLOWED),
     };
+
     format_result(result, format)
 }

--- a/indy-vdr-proxy/src/main.rs
+++ b/indy-vdr-proxy/src/main.rs
@@ -136,7 +136,7 @@ async fn refresh_pools(state: Rc<RefCell<AppState>>, delay_mins: u32) {
 
 async fn init_server(config: app::Config) -> Result<(), String> {
     let state = Rc::new(RefCell::new(
-        init_app_state(config.genesis.clone())
+        init_app_state(config.ledgers.clone())
             .await
             .map_err(|err| format!("Error loading config: {}", err))?,
     ));

--- a/indy-vdr-proxy/src/main.rs
+++ b/indy-vdr-proxy/src/main.rs
@@ -58,12 +58,12 @@ async fn init_app_state(genesis: Option<String>) -> VdrResult<AppState> {
     let vdr = match genesis {
         Some(genesis) => {
             if genesis.starts_with("http:") || genesis.starts_with("https:") {
-                Vdr::from_github(Some(genesis.as_str()))?
+                Vdr::from_github(Some(genesis.as_str()), None, None)?
             } else {
-                Vdr::from_folder(PathBuf::from(genesis), None)?
+                Vdr::from_folder(PathBuf::from(genesis), None, None)?
             }
         }
-        None => Vdr::from_github(None)?,
+        None => Vdr::from_github(None, None, None)?,
     };
 
     let state = AppState {

--- a/libindy_vdr/Cargo.toml
+++ b/libindy_vdr/Cargo.toml
@@ -21,6 +21,7 @@ logger = ["env_logger", "log"]
 zmq_vendored = ["zmq/vendored"]
 local_nodes_pool = []
 rich_schema = ["indy-data-types/rich_schema"]
+git = ["git2"]
 default = ["ffi", "log", "zmq_vendored"]
 
 [dependencies]
@@ -30,7 +31,7 @@ ffi-support = { version = "0.4", optional = true }
 futures-channel = "0.3"
 futures-executor = "0.3"
 futures-util = "0.3"
-git2 = "0.14.2"
+git2 = { version = "0.14.2", optional = true }
 hex = "0.4"
 hex-literal = "0.3.4"
 indy-data-types = "0.5"

--- a/libindy_vdr/Cargo.toml
+++ b/libindy_vdr/Cargo.toml
@@ -30,6 +30,7 @@ ffi-support = { version = "0.4", optional = true }
 futures-channel = "0.3"
 futures-executor = "0.3"
 futures-util = "0.3"
+git2 = "0.14.2"
 hex = "0.4"
 hex-literal = "0.3.4"
 indy-data-types = "0.5"

--- a/libindy_vdr/src/ffi/ledger.rs
+++ b/libindy_vdr/src/ffi/ledger.rs
@@ -413,7 +413,13 @@ pub extern "C" fn indy_vdr_build_nym_request(
         let verkey = verkey.into_opt_string();
         let alias = alias.into_opt_string();
         let role = role.into_opt_string();
-        let diddoc_content = serde_json::from_str(diddoc_content.as_str()).with_input_err("Error deserializing diddoc_content as JSON")?;
+        let diddoc_content = match diddoc_content.as_opt_str() {
+            Some(s) => {
+                let js = serde_json::from_str(s).with_input_err("Error deserializing diddoc_content as JSON")?;
+                Some(js)
+            }
+            None => None,
+        };
         let version = if version == -1 { None } else { Some(version) };
         let req = builder.build_nym_request(&identifier, &dest, verkey, alias, role, diddoc_content, version)?;
         let handle = add_request(req)?;

--- a/libindy_vdr/src/ffi/mod.rs
+++ b/libindy_vdr/src/ffi/mod.rs
@@ -19,6 +19,7 @@ mod ledger;
 mod pool;
 mod requests;
 mod resolver;
+mod vdr;
 
 use self::error::{set_last_error, ErrorCode};
 

--- a/libindy_vdr/src/ffi/resolver.rs
+++ b/libindy_vdr/src/ffi/resolver.rs
@@ -7,7 +7,7 @@ use crate::ffi::c_char;
 use ffi_support::{rust_string_to_c, FfiStr};
 
 #[no_mangle]
-pub extern "C" fn indy_vdr_resolve(
+pub extern "C" fn indy_vdr_pool_resolve(
     pool_handle: PoolHandle,
     did: FfiStr,
     cb: Option<extern "C" fn(cb_id: i64, err: ErrorCode, response: *const c_char)>,
@@ -40,7 +40,7 @@ pub extern "C" fn indy_vdr_resolve(
 }
 
 #[no_mangle]
-pub extern "C" fn indy_vdr_dereference(
+pub extern "C" fn indy_vdr_pool_dereference(
     pool_handle: PoolHandle,
     did_url: FfiStr,
     cb: Option<extern "C" fn(cb_id: i64, err: ErrorCode, response: *const c_char)>,

--- a/libindy_vdr/src/ffi/vdr.rs
+++ b/libindy_vdr/src/ffi/vdr.rs
@@ -1,1 +1,124 @@
-// TODO: Implement :)
+use crate::common::error::prelude::*;
+use crate::common::handle::ResourceHandle;
+use crate::ffi::c_char;
+use crate::vdr::RunnerVdr as Vdr;
+
+use ffi_support::{rust_string_to_c, FfiStr};
+use once_cell::sync::Lazy;
+
+use std::collections::BTreeMap;
+use std::path::PathBuf;
+use std::sync::RwLock;
+
+use super::error::{set_last_error, ErrorCode};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[repr(transparent)]
+pub struct VdrHandle(pub i64);
+
+impl_sequence_handle!(VdrHandle, FFI_PH_COUNTER);
+
+pub static VDRS: Lazy<RwLock<BTreeMap<VdrHandle, Vdr>>> =
+    Lazy::new(|| RwLock::new(BTreeMap::new()));
+
+#[cfg(feature = "git")]
+#[no_mangle]
+pub extern "C" fn indy_vdr_create_from_github(handle_p: *mut VdrHandle) -> ErrorCode {
+    catch_err! {
+        trace!("Create VDR from github");
+        check_useful_c_ptr!(handle_p);
+
+        let vdr = Vdr::from_github(None)?;
+        let handle = VdrHandle::next();
+        let mut vdrs = write_lock!(VDRS)?;
+        vdrs.insert(handle, vdr);
+        unsafe {
+            *handle_p = handle;
+        }
+        Ok(ErrorCode::Success)
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn indy_vdr_create_from_folder(
+    path: FfiStr,
+    genesis_filename: FfiStr, // Optional
+    handle_p: *mut VdrHandle,
+) -> ErrorCode {
+    catch_err! {
+        trace!("Create VDR from folder");
+        check_useful_c_ptr!(handle_p);
+
+        let path = PathBuf::from(path.as_str());
+        let genesis_filename = genesis_filename.as_opt_str();
+
+        let vdr = Vdr::from_folder(path, genesis_filename)?;
+        let handle = VdrHandle::next();
+        let mut vdrs = write_lock!(VDRS)?;
+        vdrs.insert(handle, vdr);
+        unsafe {
+            *handle_p = handle;
+        }
+        Ok(ErrorCode::Success)
+    }
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn indy_vdr_resolve(
+    vdr_handle: VdrHandle,
+    did: FfiStr,
+    cb: Option<extern "C" fn(cb_id: i64, err: ErrorCode, response: *const c_char)>,
+    cb_id: i64,
+) -> ErrorCode {
+    catch_err! {
+    trace!("Resolve DID: {:#?}", did);
+    let cb = cb.ok_or_else(|| input_err("No callback provided")).unwrap();
+    let vdrs = read_lock!(VDRS)?;
+    let vdr = vdrs.get(&vdr_handle)
+        .ok_or_else(|| input_err("Unknown VDR handle"))?;
+    vdr.resolve(did.as_str(), Box::new(move |result| {
+        let (errcode, reply) = match result {
+            Ok(status) => (ErrorCode::Success, status),
+            Err(err) => {
+                let code = ErrorCode::from(err.kind());
+                set_last_error(Some(err));
+                (code, String::new())
+            }
+        };
+        cb(cb_id, errcode, rust_string_to_c(reply))
+    }),
+            )?;
+
+        Ok(ErrorCode::Success)
+    }
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn indy_vdr_dereference(
+    vdr_handle: VdrHandle,
+    did_url: FfiStr,
+    cb: Option<extern "C" fn(cb_id: i64, err: ErrorCode, response: *const c_char)>,
+    cb_id: i64,
+) -> ErrorCode {
+    catch_err! {
+    trace!("Dereference DID: {:#?}", did_url);
+    let cb = cb.ok_or_else(|| input_err("No callback provided")).unwrap();
+    let vdrs = read_lock!(VDRS)?;
+    let vdr = vdrs.get(&vdr_handle)
+        .ok_or_else(|| input_err("Unknown VDR handle"))?;
+    vdr.dereference(did_url.as_str(), Box::new(move |result| {
+        let (errcode, reply) = match result {
+            Ok(status) => (ErrorCode::Success, status),
+            Err(err) => {
+                let code = ErrorCode::from(err.kind());
+                set_last_error(Some(err));
+                (code, String::new())
+            }
+        };
+        cb(cb_id, errcode, rust_string_to_c(reply))
+    }),
+            )?;
+
+        Ok(ErrorCode::Success)
+    }
+}

--- a/libindy_vdr/src/ffi/vdr.rs
+++ b/libindy_vdr/src/ffi/vdr.rs
@@ -1,7 +1,10 @@
 use crate::common::error::prelude::*;
 use crate::common::handle::ResourceHandle;
 use crate::ffi::c_char;
+use crate::pool::{PoolBuilder, PoolTransactions};
 use crate::vdr::RunnerVdr as Vdr;
+
+use super::POOL_CONFIG;
 
 use ffi_support::{rust_string_to_c, FfiStr};
 use once_cell::sync::Lazy;
@@ -9,6 +12,7 @@ use once_cell::sync::Lazy;
 use std::collections::BTreeMap;
 use std::path::PathBuf;
 use std::sync::RwLock;
+use std::thread;
 
 use super::error::{set_last_error, ErrorCode};
 
@@ -120,5 +124,100 @@ pub unsafe extern "C" fn indy_vdr_dereference(
             )?;
 
         Ok(ErrorCode::Success)
+    }
+}
+
+#[allow(unused_variables)]
+fn handle_pool_refresh(
+    vdr_handle: VdrHandle,
+    ledger: String,
+    old_txns: Vec<String>,
+    new_txns: Vec<String>,
+) -> ErrorCode {
+    catch_err!(
+        debug!("Adding {} new pool transactions", new_txns.len());
+        let mut txns = PoolTransactions::from_json_transactions(old_txns)?;
+        txns.extend_from_json(&new_txns)?;
+        let builder = {
+            let gcfg = read_lock!(POOL_CONFIG)?;
+            PoolBuilder::from(gcfg.clone())
+        };
+        let pool = builder.transactions(txns)?.into_runner()?;
+        let vdrs = read_lock!(VDRS).unwrap();
+        // FIXME: Can't get mutable reference
+        // let vdr = vdrs.get_mut(&vdr_handle)
+            // .ok_or_else(|| input_err("Unknown VDR handle"))?;
+        // vdr.set_pool(ledger, pool);
+        Ok(ErrorCode::Success)
+    )
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn indy_vdr_refresh(
+    vdr_handle: VdrHandle,
+    ledger: FfiStr,
+    cb: Option<extern "C" fn(cb_id: i64, err: ErrorCode)>,
+    cb_id: i64,
+) -> ErrorCode {
+    catch_err! {
+    trace!("Refresh ledger: {:#?}", ledger);
+    let cb = cb.ok_or_else(|| input_err("No callback provided")).unwrap();
+    let vdrs = read_lock!(VDRS)?;
+    let vdr = vdrs.get(&vdr_handle)
+        .ok_or_else(|| input_err("Unknown VDR handle"))?;
+    let ledger = ledger.as_str();
+    let ledger = ledger.to_string();
+    let pool = vdr.get_pool(&ledger);
+    if let Some(pool) = pool {
+
+
+    pool.refresh(Box::new(
+        move |result| {
+            let errcode = match result {
+                Ok((old_txns, new_txns, _timing)) => {
+                    if let Some(new_txns) = new_txns {
+                        // We must spawn a new thread here because this callback
+                        // is being run in the PoolRunner's thread, and if we drop
+                        // the instance now it will create a deadlock
+                        thread::spawn(move || {
+                            let result = handle_pool_refresh(vdr_handle, ledger, old_txns, new_txns);
+                            cb(cb_id, result)
+                        });
+                        return
+                    } else {
+                        ErrorCode::Success
+                    }
+                },
+                Err(err) => {
+                    let code = ErrorCode::from(err.kind());
+                    set_last_error(Some(err));
+                    code
+                }
+            };
+            cb(cb_id, errcode)
+        }))?;
+
+    }
+    Ok(ErrorCode::Success)
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn indy_vdr_get_ledgers(
+    vdr_handle: VdrHandle,
+    handle_p: *mut *const c_char,
+) -> ErrorCode {
+    catch_err! {
+    trace!("VDR Get Ledgers");
+    let vdrs = read_lock!(VDRS)?;
+    let vdr = vdrs.get(&vdr_handle)
+        .ok_or_else(|| input_err("Unknown VDR handle"))?;
+
+    let ledgers = rust_string_to_c(vdr.get_ledgers()?.join(";"));
+    unsafe {
+        *handle_p = ledgers;
+
+    }
+    Ok(ErrorCode::Success)
     }
 }

--- a/libindy_vdr/src/ffi/vdr.rs
+++ b/libindy_vdr/src/ffi/vdr.rs
@@ -32,7 +32,7 @@ pub extern "C" fn indy_vdr_create_from_github(handle_p: *mut VdrHandle) -> Error
         trace!("Create VDR from github");
         check_useful_c_ptr!(handle_p);
 
-        let vdr = Vdr::from_github(None)?;
+        let vdr = Vdr::from_github(None, None, None)?;
         let handle = VdrHandle::next();
         let mut vdrs = write_lock!(VDRS)?;
         vdrs.insert(handle, vdr);
@@ -56,7 +56,7 @@ pub extern "C" fn indy_vdr_create_from_folder(
         let path = PathBuf::from(path.as_str());
         let genesis_filename = genesis_filename.as_opt_str();
 
-        let vdr = Vdr::from_folder(path, genesis_filename)?;
+        let vdr = Vdr::from_folder(path, genesis_filename, None)?;
         let handle = VdrHandle::next();
         let mut vdrs = write_lock!(VDRS)?;
         vdrs.insert(handle, vdr);

--- a/libindy_vdr/src/ffi/vdr.rs
+++ b/libindy_vdr/src/ffi/vdr.rs
@@ -1,0 +1,1 @@
+// TODO: Implement :)

--- a/libindy_vdr/src/lib.rs
+++ b/libindy_vdr/src/lib.rs
@@ -71,7 +71,7 @@ pub mod pool;
 pub mod resolver;
 /// State proof verification for ledger read transactions
 pub mod state_proof;
-/// Indy VDR implementation for multiple ledgers and DID resolution/derefrence support
+/// Indy VDR implementation for multiple ledgers and DID resolution/dereference support
 pub mod vdr;
 
 #[cfg(test)]

--- a/libindy_vdr/src/lib.rs
+++ b/libindy_vdr/src/lib.rs
@@ -67,10 +67,12 @@ pub mod ledger;
 /// Handling of verifier pool instances and communication
 pub mod pool;
 
-/// did:indy DID URL resolver
+/// did:indy DID URL resolver for a specific pool
 pub mod resolver;
 /// State proof verification for ledger read transactions
 pub mod state_proof;
+/// Indy VDR implementation for multiple ledgers and DID resolution/derefrence support
+pub mod vdr;
 
 #[cfg(test)]
 #[macro_use]

--- a/libindy_vdr/src/pool/mod.rs
+++ b/libindy_vdr/src/pool/mod.rs
@@ -1,5 +1,5 @@
 mod builder;
-mod genesis;
+pub mod genesis;
 /// Transaction request handlers
 pub(crate) mod handlers;
 /// Methods for performing requests against the verifier pool

--- a/libindy_vdr/src/resolver/did_document.rs
+++ b/libindy_vdr/src/resolver/did_document.rs
@@ -48,11 +48,11 @@ struct GenericService {
 #[derive(Serialize, Deserialize, PartialEq, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct DidDocument {
-    namespace: String,
-    id: String,
-    verkey: String,
-    endpoint: Option<Endpoint>,
-    diddoc_content: Option<SJsonValue>,
+    pub namespace: String,
+    pub id: String,
+    pub verkey: String,
+    pub endpoint: Option<Endpoint>,
+    pub diddoc_content: Option<SJsonValue>,
 }
 
 impl DidDocument {

--- a/libindy_vdr/src/resolver/did_document.rs
+++ b/libindy_vdr/src/resolver/did_document.rs
@@ -9,20 +9,20 @@ pub const DID_CORE_CONTEXT: &str = "https://www.w3.org/ns/did/v1";
 #[derive(Serialize, PartialEq, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct Ed25519VerificationKey2018 {
-    pub id: String,
-    pub type_: String,
-    pub controller: String,
-    pub public_key_base58: String,
+    id: String,
+    type_: String,
+    controller: String,
+    public_key_base58: String,
 }
 
 #[derive(Serialize, Deserialize, PartialEq, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct DidCommService {
-    pub id: String,
-    pub type_: String,
-    pub recipient_keys: Vec<String>,
-    pub routing_keys: Vec<String>,
-    pub priority: u8,
+    id: String,
+    type_: String,
+    recipient_keys: Vec<String>,
+    routing_keys: Vec<String>,
+    priority: u8,
 }
 
 impl DidCommService {
@@ -40,17 +40,17 @@ impl DidCommService {
 #[derive(Serialize, Deserialize, PartialEq, Debug)]
 #[serde(rename_all = "camelCase")]
 struct GenericService {
-    pub id: String,
-    pub type_: String,
-    pub service_endpoint: String,
+    id: String,
+    type_: String,
+    service_endpoint: String,
 }
 
 #[derive(Serialize, Deserialize, PartialEq, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct DidDocument {
-    pub namespace: String,
-    pub id: String,
-    pub verkey: String,
+    namespace: String,
+    id: String,
+    verkey: String,
     pub endpoint: Option<Endpoint>,
     pub diddoc_content: Option<SJsonValue>,
 }

--- a/libindy_vdr/src/resolver/mod.rs
+++ b/libindy_vdr/src/resolver/mod.rs
@@ -2,6 +2,7 @@ pub mod resolver;
 
 pub mod did;
 pub mod did_document;
+pub mod types;
 pub mod utils;
 
 pub use self::resolver::{PoolResolver, PoolRunnerResolver};

--- a/libindy_vdr/src/resolver/mod.rs
+++ b/libindy_vdr/src/resolver/mod.rs
@@ -1,6 +1,7 @@
-mod resolver;
+pub mod resolver;
 
 pub mod did;
 pub mod did_document;
+pub mod utils;
 
 pub use self::resolver::{PoolResolver, PoolRunnerResolver};

--- a/libindy_vdr/src/resolver/resolver.rs
+++ b/libindy_vdr/src/resolver/resolver.rs
@@ -228,22 +228,38 @@ impl<'a> PoolRunnerResolver<'a> {
                                     //         }),
                                     //     );
                                 } else {
-                                    let diddoc = Some(doc.to_value().unwrap());
-                                    let md = if let Metadata::DidDocumentMetadata(md) = metadata {
-                                        Some(md)
-                                    } else {
-                                        None
-                                    };
+                                    // let diddoc = Some(doc.to_value().unwrap());
+                                    // let md = if let Metadata::DidDocumentMetadata(md) = metadata {
+                                    //     Some(md)
+                                    // } else {
+                                    //     None
+                                    // };
 
-                                    let result = ResolutionResult {
-                                        did_resolution_metadata: None,
-                                        did_document: diddoc,
-                                        did_document_metadata: md,
-                                    };
-                                    if !doc.diddoc_content.is_none() {
-                                        callback(Ok(serde_json::to_string_pretty(&result).unwrap()))
-                                    }
+                                    // let result = ResolutionResult {
+                                    //     did_resolution_metadata: None,
+                                    //     did_document: diddoc,
+                                    //     did_document_metadata: md,
+                                    // };
+
+                                    //     callback(Ok(serde_json::to_string_pretty(&result).unwrap()))
                                 }
+
+                                // For now, until if/else above is used
+
+                                let diddoc = Some(doc.to_value().unwrap());
+                                let md = if let Metadata::DidDocumentMetadata(md) = metadata {
+                                    Some(md)
+                                } else {
+                                    None
+                                };
+
+                                let result = ResolutionResult {
+                                    did_resolution_metadata: None,
+                                    did_document: diddoc,
+                                    did_document_metadata: md,
+                                };
+
+                                callback(Ok(serde_json::to_string_pretty(&result).unwrap()))
                             }
                             _ => {}
                         };

--- a/libindy_vdr/src/resolver/resolver.rs
+++ b/libindy_vdr/src/resolver/resolver.rs
@@ -1,15 +1,13 @@
-use crate::utils::Qualifiable;
 use futures_executor::block_on;
 use serde_json::Value as SJsonValue;
-use time::format_description::well_known::Rfc3339;
-use time::OffsetDateTime;
 
-use super::did::{DidUrl, LedgerObject, QueryParameter};
+use super::did::DidUrl;
 use super::did_document::{DidDocument, LEGACY_INDY_SERVICE};
+use super::utils::*;
+
 use crate::common::error::prelude::*;
 use crate::ledger::responses::{Endpoint, GetNymResultV1};
 
-use crate::ledger::identifiers::{CredentialDefinitionId, RevocationRegistryId, SchemaId};
 use crate::ledger::{constants, RequestBuilder};
 use crate::pool::helpers::perform_ledger_request;
 use crate::pool::{Pool, PoolRunner, PreparedRequest, RequestResult, TimingResult};
@@ -32,32 +30,32 @@ pub enum Metadata {
 #[derive(Serialize, Deserialize, PartialEq, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct ContentMetadata {
-    node_response: SJsonValue,
-    object_type: String,
+    pub node_response: SJsonValue,
+    pub object_type: String,
 }
 
 #[derive(Serialize, Deserialize, PartialEq, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct DidDocumentMetadata {
-    node_response: SJsonValue,
-    object_type: String,
-    self_certification_version: Option<i32>,
+    pub node_response: SJsonValue,
+    pub object_type: String,
+    pub self_certification_version: Option<i32>,
 }
 
 #[derive(Serialize, Deserialize, PartialEq, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct ResolutionResult {
-    did_resolution_metadata: Option<String>,
-    did_document: Option<SJsonValue>,
-    did_document_metadata: Option<DidDocumentMetadata>,
+    pub did_resolution_metadata: Option<String>,
+    pub did_document: Option<SJsonValue>,
+    pub did_document_metadata: Option<DidDocumentMetadata>,
 }
 
 #[derive(Serialize, Deserialize, PartialEq, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct DereferencingResult {
-    dereferencing_metadata: Option<String>,
-    content_stream: Option<SJsonValue>,
-    content_metadata: Option<ContentMetadata>,
+    pub dereferencing_metadata: Option<String>,
+    pub content_stream: Option<SJsonValue>,
+    pub content_metadata: Option<ContentMetadata>,
 }
 
 /// DID (URL) Resolver interface for a pool compliant with did:indy method spec
@@ -482,176 +480,13 @@ impl<'a> PoolRunnerResolver<'a> {
 
 type Callback<R> = Box<dyn (FnOnce(R) -> ()) + Send>;
 
-fn build_request(did: &DidUrl, builder: &RequestBuilder) -> VdrResult<PreparedRequest> {
-    let request = if did.path.is_some() {
-        match LedgerObject::from_str(did.path.as_ref().unwrap().as_str())? {
-            LedgerObject::Schema(schema) => builder.build_get_schema_request(
-                None,
-                &SchemaId::new(&did.id, &schema.name, &schema.version),
-            ),
-            LedgerObject::ClaimDef(claim_def) => builder.build_get_cred_def_request(
-                None,
-                &CredentialDefinitionId::from_str(
-                    format!(
-                        "{}:3:CL:{}:{}",
-                        &did.id, claim_def.schema_seq_no, claim_def.name
-                    )
-                    .as_str(),
-                )
-                .unwrap(),
-            ),
-            LedgerObject::RevRegDef(rev_reg_def) => builder.build_get_revoc_reg_def_request(
-                None,
-                &RevocationRegistryId::from_str(
-                    format!(
-                        "{}:4:{}:3:CL:{}:{}:CL_ACCUM:{}",
-                        &did.id,
-                        &did.id,
-                        rev_reg_def.schema_seq_no,
-                        rev_reg_def.claim_def_name,
-                        rev_reg_def.tag
-                    )
-                    .as_str(),
-                )
-                .unwrap(),
-            ),
-            LedgerObject::RevRegEntry(rev_reg_entry) => {
-                // If From or To parameters, return RevRegDelta request
-                if did.query.contains_key(&QueryParameter::From)
-                    || did.query.contains_key(&QueryParameter::To)
-                {
-                    let mut from: Option<i64> = None;
-                    if did.query.contains_key(&QueryParameter::From) {
-                        from = did
-                            .query
-                            .get(&QueryParameter::From)
-                            .and_then(|d| OffsetDateTime::parse(d, &Rfc3339).ok())
-                            .and_then(|d| Some(d.unix_timestamp()));
-                    }
-
-                    let to = parse_or_now(did.query.get(&QueryParameter::To))?;
-
-                    builder.build_get_revoc_reg_delta_request(
-                        None,
-                        &RevocationRegistryId::from_str(
-                            format!(
-                                "{}:4:{}:3:CL:{}:{}:CL_ACCUM:{}",
-                                &did.id,
-                                &did.id,
-                                rev_reg_entry.schema_seq_no,
-                                rev_reg_entry.claim_def_name,
-                                rev_reg_entry.tag
-                            )
-                            .as_str(),
-                        )
-                        .unwrap(),
-                        from,
-                        to,
-                    )
-                // Else return RevRegEntry request
-                } else {
-                    let timestamp = parse_or_now(did.query.get(&QueryParameter::VersionTime))?;
-
-                    builder.build_get_revoc_reg_request(
-                        None,
-                        &RevocationRegistryId::from_str(
-                            format!(
-                                "{}:4:{}:3:CL:{}:{}:CL_ACCUM:{}",
-                                &did.id,
-                                &did.id,
-                                rev_reg_entry.schema_seq_no,
-                                rev_reg_entry.claim_def_name,
-                                rev_reg_entry.tag
-                            )
-                            .as_str(),
-                        )
-                        .unwrap(),
-                        timestamp,
-                    )
-                }
-            }
-            // This path is deprecated. Deltas can be retrieved through RevRegEntry
-            LedgerObject::RevRegDelta(rev_reg_delta) => {
-                let mut from: Option<i64> = None;
-                if did.query.contains_key(&QueryParameter::From) {
-                    from = did
-                        .query
-                        .get(&QueryParameter::From)
-                        .and_then(|d| OffsetDateTime::parse(d, &Rfc3339).ok())
-                        .and_then(|d| Some(d.unix_timestamp()));
-                }
-
-                let to = parse_or_now(did.query.get(&QueryParameter::To))?;
-
-                builder.build_get_revoc_reg_delta_request(
-                    None,
-                    &RevocationRegistryId::from_str(
-                        format!(
-                            "{}:4:{}:3:CL:{}:{}:CL_ACCUM:{}",
-                            &did.id,
-                            &did.id,
-                            rev_reg_delta.schema_seq_no,
-                            rev_reg_delta.claim_def_name,
-                            rev_reg_delta.tag
-                        )
-                        .as_str(),
-                    )
-                    .unwrap(),
-                    from,
-                    to,
-                )
-            }
-        }
-    } else {
-        let seq_no: Option<i32> = did
-            .query
-            .get(&QueryParameter::VersionId)
-            .and_then(|v| v.parse().ok());
-        let timestamp: Option<u64> = did
-            .query
-            .get(&QueryParameter::VersionTime)
-            .and_then(|d| OffsetDateTime::parse(d, &Rfc3339).ok())
-            .and_then(|d| Some(d.unix_timestamp()))
-            .and_then(|d| Some(d as u64));
-
-        builder.build_get_nym_request(Option::None, &did.id, seq_no, timestamp)
-    };
-    request
-}
-
-fn parse_ledger_data(ledger_data: &str) -> VdrResult<SJsonValue> {
-    let v: SJsonValue = serde_json::from_str(&ledger_data)
-        .map_err(|_| err_msg(VdrErrorKind::Resolver, "Could not parse ledger response"))?;
-    let data: &SJsonValue = &v["result"]["data"];
-    if *data == SJsonValue::Null {
-        Err(err_msg(
-            VdrErrorKind::Resolver,
-            format!("Empty data in ledger response"),
-        ))
-    } else {
-        Ok(data.to_owned())
-    }
-}
-
-fn parse_or_now(datetime: Option<&String>) -> VdrResult<i64> {
-    match datetime {
-        Some(datetime) => {
-            let dt = OffsetDateTime::parse(datetime, &Rfc3339).map_err(|_| {
-                err_msg(
-                    VdrErrorKind::Resolver,
-                    format!("Could not parse datetime {}", datetime),
-                )
-            })?;
-            Ok(dt.unix_timestamp())
-        }
-        None => Ok(OffsetDateTime::now_utc().unix_timestamp()),
-    }
-}
-
 #[cfg(test)]
 mod tests {
 
     use urlencoding::encode;
+
+    use time::format_description::well_known::Rfc3339;
+    use time::OffsetDateTime;
 
     use super::*;
     use rstest::*;

--- a/libindy_vdr/src/resolver/resolver.rs
+++ b/libindy_vdr/src/resolver/resolver.rs
@@ -1,17 +1,13 @@
-use futures_executor::block_on;
 use serde_json::Value as SJsonValue;
 
 use super::did::DidUrl;
-use super::did_document::{DidDocument, LEGACY_INDY_SERVICE};
+use super::did_document::DidDocument;
 use super::utils::*;
 
 use crate::common::error::prelude::*;
-use crate::ledger::responses::{Endpoint, GetNymResultV1};
 
-use crate::ledger::{constants, RequestBuilder};
-use crate::pool::helpers::perform_ledger_request;
-use crate::pool::{Pool, PoolRunner, PreparedRequest, RequestResult, TimingResult};
-use crate::utils::did::DidValue;
+use crate::ledger::RequestBuilder;
+use crate::pool::{Pool, PoolRunner, RequestResult, TimingResult};
 
 #[derive(Serialize, Deserialize, PartialEq, Debug)]
 #[serde(rename_all = "camelCase")]
@@ -58,6 +54,14 @@ pub struct DereferencingResult {
     pub content_metadata: Option<ContentMetadata>,
 }
 
+pub trait Resolver {
+    fn resolve(&self, did_url: &str) -> VdrResult<String>;
+
+    fn dereference(&self, did_url: &str) -> VdrResult<String>;
+}
+
+pub trait CallbackResolver {}
+
 /// DID (URL) Resolver interface for a pool compliant with did:indy method spec
 pub struct PoolResolver<T: Pool> {
     pool: T,
@@ -69,9 +73,10 @@ impl<T: Pool> PoolResolver<T> {
     }
 
     /// Dereference a DID Url and return a serialized `DereferencingResult`
-    pub fn dereference(&self, did_url: &str) -> VdrResult<String> {
+    pub async fn dereference(&self, did_url: &str) -> VdrResult<String> {
         debug!("PoolResolver: Dereference DID Url {}", did_url);
-        let (data, metadata) = self._resolve(did_url)?;
+        let did_url = DidUrl::from_str(did_url)?;
+        let (data, metadata) = self._resolve(&did_url).await?;
 
         let content = match data {
             Result::Content(c) => Some(c),
@@ -94,12 +99,19 @@ impl<T: Pool> PoolResolver<T> {
     }
 
     /// Resolve a DID and return a serialized `ResolutionResult`
-    pub fn resolve(&self, did: &str) -> VdrResult<String> {
+    pub async fn resolve(&self, did: &str) -> VdrResult<String> {
         debug!("PoolResolver: Resolve DID {}", did);
-        let (data, metadata) = self._resolve(did)?;
+        let did = DidUrl::from_str(did)?;
+        let (data, metadata) = self._resolve(&did).await?;
 
         let diddoc = match data {
-            Result::DidDocument(doc) => Some(doc.to_value()?),
+            Result::DidDocument(mut doc) => {
+                // Try to find legacy endpoint using a GET_ATTRIB txn if diddoc_content is none
+                if doc.diddoc_content.is_none() {
+                    doc.endpoint = fetch_legacy_endpoint(&self.pool, &did.id).await.ok();
+                }
+                Some(doc.to_value()?)
+            }
             _ => None,
         };
 
@@ -119,115 +131,15 @@ impl<T: Pool> PoolResolver<T> {
     }
 
     // Internal method to resolve and dereference
-    fn _resolve(&self, did: &str) -> VdrResult<(Result, Metadata)> {
-        let did_url = DidUrl::from_str(did)?;
-
+    async fn _resolve(&self, did_url: &DidUrl) -> VdrResult<(Result, Metadata)> {
         let builder = self.pool.get_request_builder();
         let request = build_request(&did_url, &builder)?;
 
-        let ledger_data = self.handle_request(&request)?;
-        let data = parse_ledger_data(&ledger_data)?;
+        let ledger_data = handle_request(&self.pool, &request).await?;
+        let txn_type = &request.txn_type.as_str();
+        let result = handle_resolution_result(&did_url, &ledger_data, txn_type)?;
 
-        let (result, metadata) = match request.txn_type.as_str() {
-            constants::GET_NYM => {
-                let get_nym_result: GetNymResultV1 =
-                    serde_json::from_str(data.as_str().unwrap())
-                        .map_err(|_| err_msg(VdrErrorKind::Resolver, "Could not parse NYM data"))?;
-
-                let endpoint: Option<Endpoint> = if get_nym_result.diddoc_content.is_none() {
-                    // Legacy: Try to find an attached ATTRIBUTE transacation with raw endpoint
-                    self.fetch_legacy_endpoint(&did_url.id).ok()
-                } else {
-                    None
-                };
-
-                let did_document = DidDocument::new(
-                    &did_url.namespace,
-                    &get_nym_result.dest,
-                    &get_nym_result.verkey,
-                    endpoint,
-                    None,
-                );
-
-                let metadata = Metadata::DidDocumentMetadata(DidDocumentMetadata {
-                    node_response: serde_json::from_str(&ledger_data).unwrap(),
-                    object_type: String::from("NYM"),
-                    self_certification_version: get_nym_result.version,
-                });
-
-                (Result::DidDocument(did_document), metadata)
-            }
-            constants::GET_CRED_DEF => (
-                Result::Content(data),
-                Metadata::ContentMetadata(ContentMetadata {
-                    node_response: serde_json::from_str(&ledger_data).unwrap(),
-                    object_type: String::from("CRED_DEF"),
-                }),
-            ),
-            constants::GET_SCHEMA => (
-                Result::Content(data),
-                Metadata::ContentMetadata(ContentMetadata {
-                    node_response: serde_json::from_str(&ledger_data).unwrap(),
-                    object_type: String::from("SCHEMA"),
-                }),
-            ),
-            constants::GET_REVOC_REG_DEF => (
-                Result::Content(data),
-                Metadata::ContentMetadata(ContentMetadata {
-                    node_response: serde_json::from_str(&ledger_data).unwrap(),
-                    object_type: String::from("REVOC_REG_DEF"),
-                }),
-            ),
-            constants::GET_REVOC_REG_DELTA => (
-                Result::Content(data),
-                Metadata::ContentMetadata(ContentMetadata {
-                    node_response: serde_json::from_str(&ledger_data).unwrap(),
-                    object_type: String::from("REVOC_REG_DELTA"),
-                }),
-            ),
-            _ => (
-                Result::Content(data),
-                Metadata::ContentMetadata(ContentMetadata {
-                    node_response: serde_json::from_str(&ledger_data).unwrap(),
-                    object_type: String::from("REVOC_REG_DELTA"),
-                }),
-            ),
-        };
-
-        let result_with_metadata = (result, metadata);
-
-        Ok(result_with_metadata)
-    }
-
-    fn fetch_legacy_endpoint(&self, did: &DidValue) -> VdrResult<Endpoint> {
-        let builder = self.pool.get_request_builder();
-        let request = builder.build_get_attrib_request(
-            None,
-            did,
-            Some(String::from(LEGACY_INDY_SERVICE)),
-            None,
-            None,
-        )?;
-        let ledger_data = self.handle_request(&request)?;
-        let endpoint_data = parse_ledger_data(&ledger_data)?;
-        let endpoint_data: Endpoint = serde_json::from_str(endpoint_data.as_str().unwrap())
-            .map_err(|_| err_msg(VdrErrorKind::Resolver, "Could not parse endpoint data"))?;
-        Ok(endpoint_data)
-    }
-
-    fn handle_request(&self, request: &PreparedRequest) -> VdrResult<String> {
-        let (result, _timing) = block_on(self.request_transaction(&request))?;
-        match result {
-            RequestResult::Reply(data) => Ok(data),
-            RequestResult::Failed(error) => Err(error),
-        }
-    }
-
-    async fn request_transaction(
-        &self,
-        request: &PreparedRequest,
-    ) -> VdrResult<(RequestResult<String>, Option<TimingResult>)> {
-        perform_ledger_request(&self.pool, &request).await
+        Ok(result)
     }
 }
 
@@ -277,32 +189,74 @@ impl<'a> PoolRunnerResolver<'a> {
     pub fn resolve(&self, did: &str, callback: Callback<VdrResult<String>>) -> VdrResult<()> {
         self._resolve(
             did,
-            Box::new(move |result| {
-                let (data, metadata) = result.unwrap();
-                let diddoc = match data {
-                    Result::DidDocument(doc) => Some(doc.to_value().unwrap()),
-                    _ => None,
-                };
+            Box::new(|result| {
+                match result {
+                    Ok((data, metadata)) => {
+                        match data {
+                            // TODO: Doc needs to be mutable, when we uncomment
+                            Result::DidDocument(doc) => {
+                                // Try to find legacy endpoint using a GET_ATTRIB txn if diddoc_content is none
+                                if doc.diddoc_content.is_none() {
+                                    //     let pool = self
+                                    //         .pools
+                                    //         .get(&did.namespace)
+                                    //         .ok_or(err_msg(VdrErrorKind::Resolver, "Unkown namespace"))
+                                    //         .unwrap();
+                                    //     fetch_legacy_endpoint_with_runner(
+                                    //         pool,
+                                    //         &did.id,
+                                    //         Box::new(|result| {
+                                    //             doc.endpoint = result.ok();
+                                    //             let diddoc = Some(doc.to_value().unwrap());
+                                    //             let md = if let Metadata::DidDocumentMetadata(md) =
+                                    //                 metadata
+                                    //             {
+                                    //                 Some(md)
+                                    //             } else {
+                                    //                 None
+                                    //             };
 
-                let md = if let Metadata::DidDocumentMetadata(md) = metadata {
-                    Some(md)
-                } else {
-                    None
-                };
+                                    //             let result = ResolutionResult {
+                                    //                 did_resolution_metadata: None,
+                                    //                 did_document: diddoc,
+                                    //                 did_document_metadata: md,
+                                    //             };
 
-                let result = ResolutionResult {
-                    did_resolution_metadata: None,
-                    did_document: diddoc,
-                    did_document_metadata: md,
-                };
+                                    //             callback(Ok(
+                                    //                 serde_json::to_string_pretty(&result).unwrap()
+                                    //             ))
+                                    //         }),
+                                    //     );
+                                } else {
+                                    let diddoc = Some(doc.to_value().unwrap());
+                                    let md = if let Metadata::DidDocumentMetadata(md) = metadata {
+                                        Some(md)
+                                    } else {
+                                        None
+                                    };
 
-                callback(Ok(serde_json::to_string_pretty(&result).unwrap()))
+                                    let result = ResolutionResult {
+                                        did_resolution_metadata: None,
+                                        did_document: diddoc,
+                                        did_document_metadata: md,
+                                    };
+                                    if !doc.diddoc_content.is_none() {
+                                        callback(Ok(serde_json::to_string_pretty(&result).unwrap()))
+                                    }
+                                }
+                            }
+                            _ => {}
+                        };
+                    }
+                    // TODO: How to handle errors?
+                    Err(_err) => {}
+                }
             }),
-        )
+        )?;
+        Ok(())
     }
 
     // TODO: Refactor
-    // TODO: Adapt according to PoolResolver.
     fn _resolve(
         &self,
         did: &str,
@@ -313,301 +267,26 @@ impl<'a> PoolRunnerResolver<'a> {
         let builder = RequestBuilder::default();
         let request = build_request(&did_url, &builder)?;
         let txn_type = request.txn_type.clone();
+
         self.runner.send_request(
             request,
             Box::new(
                 move |result: VdrResult<(RequestResult<String>, Option<TimingResult>)>| {
-                    match result {
-                        Ok((reply, _)) => {
-                            match reply {
-                                RequestResult::Reply(reply_data) => {
-                                    let data = parse_ledger_data(&reply_data).unwrap();
-                                    if txn_type.as_str() == constants::GET_NYM {
-                                        let get_nym_result: GetNymResultV1 =
-                                            serde_json::from_str(data.as_str().unwrap()).unwrap();
-
-                                        // TODO: Fix fetch_legacy_endpoint
-                                        // let did = did_url.id.clone();
-                                        if get_nym_result.diddoc_content.is_none() {
-                                            // Legacy: Try to find an attached ATTRIBUTE transacation with raw endpoint
-                                            // self._fetch_legacy_endpoint(
-                                            //     &did,
-                                            //     Box::new(move |result| {
-                                            //         let did_document = DidDocument::new(
-                                            //             &did_url.namespace,
-                                            //             &get_nym_result.dest,
-                                            //             &get_nym_result.verkey,
-                                            //             result.ok(),
-                                            //             None,
-                                            //         );
-
-                                            //         let metadata = ContentMetadata {
-                                            //             node_response: serde_json::from_str(
-                                            //                 &reply_data,
-                                            //             )
-                                            //             .unwrap(),
-                                            //             object_type: String::from("NYM"),
-                                            //         };
-
-                                            //         let result =
-                                            //             Some(Result::DidDocument(did_document));
-
-                                            //         let result_with_metadata =
-                                            //             (result.unwrap(), metadata);
-                                            //         callback(Ok(result_with_metadata));
-                                            //     }),
-                                            // );
-                                        }
-
-                                        let did_document = DidDocument::new(
-                                            &did_url.namespace,
-                                            &get_nym_result.dest,
-                                            &get_nym_result.verkey,
-                                            None,
-                                            None,
-                                        );
-
-                                        let metadata =
-                                            Metadata::DidDocumentMetadata(DidDocumentMetadata {
-                                                node_response: serde_json::from_str(&reply_data)
-                                                    .unwrap(),
-                                                object_type: String::from("NYM"),
-                                                self_certification_version: get_nym_result.version,
-                                            });
-
-                                        let result = Some(Result::DidDocument(did_document));
-
-                                        let result_with_metadata = (result.unwrap(), metadata);
-                                        callback(Ok(result_with_metadata));
-                                    } else {
-                                        let (result, metadata) = match txn_type.as_str() {
-                                            constants::GET_CRED_DEF => (
-                                                Result::Content(data),
-                                                Metadata::ContentMetadata(ContentMetadata {
-                                                    node_response: serde_json::from_str(
-                                                        &reply_data,
-                                                    )
-                                                    .unwrap(),
-                                                    object_type: String::from("CRED_DEF"),
-                                                }),
-                                            ),
-                                            constants::GET_SCHEMA => (
-                                                Result::Content(data),
-                                                Metadata::ContentMetadata(ContentMetadata {
-                                                    node_response: serde_json::from_str(
-                                                        &reply_data,
-                                                    )
-                                                    .unwrap(),
-                                                    object_type: String::from("SCHEMA"),
-                                                }),
-                                            ),
-                                            constants::GET_REVOC_REG_DEF => (
-                                                Result::Content(data),
-                                                Metadata::ContentMetadata(ContentMetadata {
-                                                    node_response: serde_json::from_str(
-                                                        &reply_data,
-                                                    )
-                                                    .unwrap(),
-                                                    object_type: String::from("REVOC_REG_DEF"),
-                                                }),
-                                            ),
-                                            constants::GET_REVOC_REG_DELTA => (
-                                                Result::Content(data),
-                                                Metadata::ContentMetadata(ContentMetadata {
-                                                    node_response: serde_json::from_str(
-                                                        &reply_data,
-                                                    )
-                                                    .unwrap(),
-                                                    object_type: String::from("REVOC_REG_DELTA"),
-                                                }),
-                                            ),
-                                            _ => (
-                                                Result::Content(data),
-                                                Metadata::ContentMetadata(ContentMetadata {
-                                                    node_response: serde_json::from_str(
-                                                        &reply_data,
-                                                    )
-                                                    .unwrap(),
-                                                    object_type: String::from("REVOC_REG_DELTA"),
-                                                }),
-                                            ),
-                                        };
-
-                                        let result_with_metadata = (result, metadata);
-                                        callback(Ok(result_with_metadata));
-                                    }
-                                }
-                                RequestResult::Failed(err) => callback(Err(err)),
-                            }
-                        }
-                        Err(err) => callback(Err(err)),
+                    let ledger_data = match result {
+                        Ok((reply, _)) => match reply {
+                            RequestResult::Reply(reply_data) => Ok(reply_data),
+                            RequestResult::Failed(err) => Err(err),
+                        },
+                        Err(err) => Err(err),
                     }
+                    .unwrap();
+
+                    let result =
+                        handle_resolution_result(&did_url, &ledger_data, txn_type.as_str())
+                            .unwrap();
+                    callback(Ok(result))
                 },
             ),
         )
-    }
-
-    fn _fetch_legacy_endpoint(
-        &self,
-        did: &DidValue,
-        callback: Callback<VdrResult<Endpoint>>,
-    ) -> VdrResult<()> {
-        let builder = RequestBuilder::default();
-        let request = builder.build_get_attrib_request(
-            None,
-            did,
-            Some(String::from(LEGACY_INDY_SERVICE)),
-            None,
-            None,
-        )?;
-        self.runner.send_request(
-            request,
-            Box::new(move |result| match result {
-                Ok((res, _)) => match res {
-                    RequestResult::Reply(reply_data) => {
-                        let endpoint_data = parse_ledger_data(&reply_data).unwrap();
-                        let endpoint_data: Endpoint =
-                            serde_json::from_str(endpoint_data.as_str().unwrap()).unwrap();
-                        callback(Ok(endpoint_data));
-                    }
-                    RequestResult::Failed(err) => callback(Err(err)),
-                },
-                Err(err) => callback(Err(err)),
-            }),
-        )
-    }
-}
-
-type Callback<R> = Box<dyn (FnOnce(R) -> ()) + Send>;
-
-#[cfg(test)]
-mod tests {
-
-    use urlencoding::encode;
-
-    use time::format_description::well_known::Rfc3339;
-    use time::OffsetDateTime;
-
-    use super::*;
-    use rstest::*;
-
-    use crate::pool::ProtocolVersion;
-
-    #[fixture]
-    fn request_builder() -> RequestBuilder {
-        RequestBuilder::new(ProtocolVersion::Node1_4)
-    }
-
-    #[rstest]
-    fn build_get_revoc_reg_request_from_version_time(request_builder: RequestBuilder) {
-        let datetime_as_str = "2020-12-20T19:17:47Z";
-        let did_url_as_str = format!("did:indy:idunion:Dk1fRRTtNazyMuK2cr64wp/anoncreds/v0/REV_REG_ENTRY/104/revocable/a4e25e54?versionTime={}",datetime_as_str);
-        let did_url = DidUrl::from_str(&did_url_as_str).unwrap();
-        let request = build_request(&did_url, &request_builder).unwrap();
-        let timestamp = (*(request.req_json).get("operation").unwrap())
-            .get("timestamp")
-            .unwrap()
-            .as_u64()
-            .unwrap() as i64;
-        assert_eq!(constants::GET_REVOC_REG, request.txn_type);
-
-        assert_eq!(
-            OffsetDateTime::parse(datetime_as_str, &Rfc3339)
-                .unwrap()
-                .unix_timestamp(),
-            timestamp
-        );
-    }
-
-    #[rstest]
-    fn build_get_revoc_reg_without_version_time(request_builder: RequestBuilder) {
-        let now = OffsetDateTime::now_utc().unix_timestamp();
-
-        let did_url_as_str = "did:indy:idunion:Dk1fRRTtNazyMuK2cr64wp/anoncreds/v0/REV_REG_ENTRY/104/revocable/a4e25e54";
-        let did_url = DidUrl::from_str(did_url_as_str).unwrap();
-        let request = build_request(&did_url, &request_builder).unwrap();
-        let timestamp = (*(request.req_json).get("operation").unwrap())
-            .get("timestamp")
-            .unwrap()
-            .as_u64()
-            .unwrap() as i64;
-
-        assert_eq!(constants::GET_REVOC_REG, request.txn_type);
-        assert!(timestamp >= now);
-    }
-
-    #[rstest]
-    fn build_get_revoc_reg_request_fails_with_unparsable_version_time(
-        request_builder: RequestBuilder,
-    ) {
-        let datetime_as_str = "20201220T19:17:47Z";
-        let did_url_as_str = format!("did:indy:idunion:Dk1fRRTtNazyMuK2cr64wp/anoncreds/v0/REV_REG_ENTRY/104/revocable/a4e25e54?versionTime={}",datetime_as_str);
-        let did_url = DidUrl::from_str(&did_url_as_str).unwrap();
-        let _err = build_request(&did_url, &request_builder).unwrap_err();
-    }
-
-    #[rstest]
-    fn build_get_revoc_reg_delta_request_with_from_to(request_builder: RequestBuilder) {
-        let from_as_str = "2019-12-20T19:17:47Z";
-        let to_as_str = "2020-12-20T19:17:47Z";
-        let did_url_as_str = format!("did:indy:idunion:Dk1fRRTtNazyMuK2cr64wp/anoncreds/v0/REV_REG_ENTRY/104/revocable/a4e25e54?from={}&to={}",from_as_str, to_as_str);
-        let did_url = DidUrl::from_str(&did_url_as_str).unwrap();
-        let request = build_request(&did_url, &request_builder).unwrap();
-        assert_eq!(request.txn_type, constants::GET_REVOC_REG_DELTA);
-    }
-
-    #[rstest]
-    fn build_get_revoc_reg_delta_request_with_from_only(request_builder: RequestBuilder) {
-        let now = OffsetDateTime::now_utc().unix_timestamp();
-        let from_as_str = "2019-12-20T19:17:47Z";
-        let did_url_as_str = format!("did:indy:idunion:Dk1fRRTtNazyMuK2cr64wp/anoncreds/v0/REV_REG_ENTRY/104/revocable/a4e25e54?from={}",from_as_str);
-        let did_url = DidUrl::from_str(&did_url_as_str).unwrap();
-        let request = build_request(&did_url, &request_builder).unwrap();
-
-        let to = (*(request.req_json).get("operation").unwrap())
-            .get("to")
-            .unwrap()
-            .as_u64()
-            .unwrap() as i64;
-        assert_eq!(request.txn_type, constants::GET_REVOC_REG_DELTA);
-        assert!(to >= now)
-    }
-
-    #[rstest]
-    fn build_get_revoc_reg_delta_request_without_parameter(request_builder: RequestBuilder) {
-        let now = OffsetDateTime::now_utc().unix_timestamp();
-        let did_url_as_str = "did:indy:idunion:Dk1fRRTtNazyMuK2cr64wp/anoncreds/v0/REV_REG_DELTA/104/revocable/a4e25e54";
-        let did_url = DidUrl::from_str(did_url_as_str).unwrap();
-        let request = build_request(&did_url, &request_builder).unwrap();
-
-        let to = (*(request.req_json).get("operation").unwrap())
-            .get("to")
-            .unwrap()
-            .as_u64()
-            .unwrap() as i64;
-
-        let from = (*(request.req_json).get("operation").unwrap()).get("from");
-        assert_eq!(request.txn_type, constants::GET_REVOC_REG_DELTA);
-        assert!(from.is_none());
-        assert!(to >= now);
-    }
-
-    #[rstest]
-    fn build_get_schema_request_with_whitespace(request_builder: RequestBuilder) {
-        let name = "My Schema";
-        let encoded_schema_name = encode(name).to_string();
-        let did_url_string = format!(
-            "did:indy:idunion:Dk1fRRTtNazyMuK2cr64wp/anoncreds/v0/SCHEMA/{}/1.0",
-            encoded_schema_name
-        );
-
-        let did_url = DidUrl::from_str(did_url_string.as_str()).unwrap();
-        let request = build_request(&did_url, &request_builder).unwrap();
-        let schema_name = (*(request.req_json).get("operation").unwrap())
-            .get("data")
-            .and_then(|v| v.get("name"))
-            .and_then(|v| v.as_str())
-            .unwrap();
-        assert_eq!(schema_name, name);
     }
 }

--- a/libindy_vdr/src/resolver/resolver.rs
+++ b/libindy_vdr/src/resolver/resolver.rs
@@ -1,66 +1,11 @@
-use serde_json::Value as SJsonValue;
-
 use super::did::DidUrl;
-use super::did_document::DidDocument;
+use super::types::*;
 use super::utils::*;
 
 use crate::common::error::prelude::*;
 
 use crate::ledger::RequestBuilder;
 use crate::pool::{Pool, PoolRunner, RequestResult, TimingResult};
-
-#[derive(Serialize, Deserialize, PartialEq, Debug)]
-#[serde(rename_all = "camelCase")]
-pub enum Result {
-    DidDocument(DidDocument),
-    Content(SJsonValue),
-}
-
-#[derive(Serialize, Deserialize, PartialEq, Debug)]
-#[serde(rename_all = "camelCase")]
-pub enum Metadata {
-    DidDocumentMetadata(DidDocumentMetadata),
-    ContentMetadata(ContentMetadata),
-}
-
-#[derive(Serialize, Deserialize, PartialEq, Debug)]
-#[serde(rename_all = "camelCase")]
-pub struct ContentMetadata {
-    pub node_response: SJsonValue,
-    pub object_type: String,
-}
-
-#[derive(Serialize, Deserialize, PartialEq, Debug)]
-#[serde(rename_all = "camelCase")]
-pub struct DidDocumentMetadata {
-    pub node_response: SJsonValue,
-    pub object_type: String,
-    pub self_certification_version: Option<i32>,
-}
-
-#[derive(Serialize, Deserialize, PartialEq, Debug)]
-#[serde(rename_all = "camelCase")]
-pub struct ResolutionResult {
-    pub did_resolution_metadata: Option<String>,
-    pub did_document: Option<SJsonValue>,
-    pub did_document_metadata: Option<DidDocumentMetadata>,
-}
-
-#[derive(Serialize, Deserialize, PartialEq, Debug)]
-#[serde(rename_all = "camelCase")]
-pub struct DereferencingResult {
-    pub dereferencing_metadata: Option<String>,
-    pub content_stream: Option<SJsonValue>,
-    pub content_metadata: Option<ContentMetadata>,
-}
-
-pub trait Resolver {
-    fn resolve(&self, did_url: &str) -> VdrResult<String>;
-
-    fn dereference(&self, did_url: &str) -> VdrResult<String>;
-}
-
-pub trait CallbackResolver {}
 
 /// DID (URL) Resolver interface for a pool compliant with did:indy method spec
 pub struct PoolResolver<T: Pool> {

--- a/libindy_vdr/src/resolver/types.rs
+++ b/libindy_vdr/src/resolver/types.rs
@@ -1,0 +1,48 @@
+use serde_json::Value as SJsonValue;
+
+use super::did_document::DidDocument;
+
+#[derive(Serialize, Deserialize, PartialEq, Debug)]
+#[serde(rename_all = "camelCase")]
+pub enum Result {
+    DidDocument(DidDocument),
+    Content(SJsonValue),
+}
+
+#[derive(Serialize, Deserialize, PartialEq, Debug)]
+#[serde(rename_all = "camelCase")]
+pub enum Metadata {
+    DidDocumentMetadata(DidDocumentMetadata),
+    ContentMetadata(ContentMetadata),
+}
+
+#[derive(Serialize, Deserialize, PartialEq, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct ContentMetadata {
+    pub node_response: SJsonValue,
+    pub object_type: String,
+}
+
+#[derive(Serialize, Deserialize, PartialEq, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct DidDocumentMetadata {
+    pub node_response: SJsonValue,
+    pub object_type: String,
+    pub self_certification_version: Option<i32>,
+}
+
+#[derive(Serialize, Deserialize, PartialEq, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct ResolutionResult {
+    pub did_resolution_metadata: Option<String>,
+    pub did_document: Option<SJsonValue>,
+    pub did_document_metadata: Option<DidDocumentMetadata>,
+}
+
+#[derive(Serialize, Deserialize, PartialEq, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct DereferencingResult {
+    pub dereferencing_metadata: Option<String>,
+    pub content_stream: Option<SJsonValue>,
+    pub content_metadata: Option<ContentMetadata>,
+}

--- a/libindy_vdr/src/resolver/types.rs
+++ b/libindy_vdr/src/resolver/types.rs
@@ -2,6 +2,8 @@ use serde_json::Value as SJsonValue;
 
 use super::did_document::DidDocument;
 
+pub type Callback<R> = Box<dyn (FnOnce(R) -> ()) + Send>;
+
 #[derive(Serialize, Deserialize, PartialEq, Debug)]
 #[serde(rename_all = "camelCase")]
 pub enum Result {

--- a/libindy_vdr/src/resolver/utils.rs
+++ b/libindy_vdr/src/resolver/utils.rs
@@ -3,16 +3,20 @@ use time::format_description::well_known::Rfc3339;
 use time::OffsetDateTime;
 
 use super::did::{DidUrl, LedgerObject, QueryParameter};
-use super::did_document::DidDocument;
+use super::did_document::{DidDocument, LEGACY_INDY_SERVICE};
 use super::resolver::*;
 
 use crate::common::error::prelude::*;
 use crate::ledger::constants;
 use crate::ledger::identifiers::{CredentialDefinitionId, RevocationRegistryId, SchemaId};
-use crate::ledger::responses::GetNymResultV1;
+use crate::ledger::responses::{Endpoint, GetNymResultV1};
 use crate::ledger::RequestBuilder;
-use crate::pool::PreparedRequest;
+use crate::pool::helpers::perform_ledger_request;
+use crate::pool::{Pool, PoolRunner, PreparedRequest, RequestResult, TimingResult};
+use crate::utils::did::DidValue;
 use crate::utils::Qualifiable;
+
+pub type Callback<R> = Box<dyn (FnOnce(R) -> ()) + Send>;
 
 pub fn build_request(did: &DidUrl, builder: &RequestBuilder) -> VdrResult<PreparedRequest> {
     let request = if did.path.is_some() {
@@ -242,5 +246,199 @@ pub fn parse_or_now(datetime: Option<&String>) -> VdrResult<i64> {
             Ok(dt.unix_timestamp())
         }
         None => Ok(OffsetDateTime::now_utc().unix_timestamp()),
+    }
+}
+
+pub async fn handle_request<T: Pool>(pool: &T, request: &PreparedRequest) -> VdrResult<String> {
+    let (result, _timing) = request_transaction(pool, &request).await?;
+    match result {
+        RequestResult::Reply(data) => Ok(data),
+        RequestResult::Failed(error) => Err(error),
+    }
+}
+
+pub async fn request_transaction<T: Pool>(
+    pool: &T,
+    request: &PreparedRequest,
+) -> VdrResult<(RequestResult<String>, Option<TimingResult>)> {
+    perform_ledger_request(pool, &request).await
+}
+
+/// Fetch legacy service endpoint using ATTRIB tx
+pub async fn fetch_legacy_endpoint<T: Pool>(pool: &T, did: &DidValue) -> VdrResult<Endpoint> {
+    let builder = pool.get_request_builder();
+    let request = builder.build_get_attrib_request(
+        None,
+        did,
+        Some(String::from(LEGACY_INDY_SERVICE)),
+        None,
+        None,
+    )?;
+    let ledger_data = handle_request(pool, &request).await?;
+    let endpoint_data = parse_ledger_data(&ledger_data)?;
+    let endpoint_data: Endpoint = serde_json::from_str(endpoint_data.as_str().unwrap())
+        .map_err(|_| err_msg(VdrErrorKind::Resolver, "Could not parse endpoint data"))?;
+    Ok(endpoint_data)
+}
+
+pub fn fetch_legacy_endpoint_with_runner(
+    runner: &PoolRunner,
+    did: &DidValue,
+    callback: Callback<VdrResult<Endpoint>>,
+) -> VdrResult<()> {
+    let builder = RequestBuilder::default();
+    let request = builder.build_get_attrib_request(
+        None,
+        did,
+        Some(String::from(LEGACY_INDY_SERVICE)),
+        None,
+        None,
+    )?;
+    runner.send_request(
+        request,
+        Box::new(move |result| match result {
+            Ok((res, _)) => match res {
+                RequestResult::Reply(reply_data) => {
+                    let endpoint_data = parse_ledger_data(&reply_data).unwrap();
+                    let endpoint_data: Endpoint =
+                        serde_json::from_str(endpoint_data.as_str().unwrap()).unwrap();
+                    callback(Ok(endpoint_data));
+                }
+                RequestResult::Failed(err) => callback(Err(err)),
+            },
+            Err(err) => callback(Err(err)),
+        }),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+
+    use urlencoding::encode;
+
+    use time::format_description::well_known::Rfc3339;
+    use time::OffsetDateTime;
+
+    use super::*;
+    use rstest::*;
+
+    use crate::pool::ProtocolVersion;
+
+    #[fixture]
+    fn request_builder() -> RequestBuilder {
+        RequestBuilder::new(ProtocolVersion::Node1_4)
+    }
+
+    #[rstest]
+    fn build_get_revoc_reg_request_from_version_time(request_builder: RequestBuilder) {
+        let datetime_as_str = "2020-12-20T19:17:47Z";
+        let did_url_as_str = format!("did:indy:idunion:Dk1fRRTtNazyMuK2cr64wp/anoncreds/v0/REV_REG_ENTRY/104/revocable/a4e25e54?versionTime={}",datetime_as_str);
+        let did_url = DidUrl::from_str(&did_url_as_str).unwrap();
+        let request = build_request(&did_url, &request_builder).unwrap();
+        let timestamp = (*(request.req_json).get("operation").unwrap())
+            .get("timestamp")
+            .unwrap()
+            .as_u64()
+            .unwrap() as i64;
+        assert_eq!(constants::GET_REVOC_REG, request.txn_type);
+
+        assert_eq!(
+            OffsetDateTime::parse(datetime_as_str, &Rfc3339)
+                .unwrap()
+                .unix_timestamp(),
+            timestamp
+        );
+    }
+
+    #[rstest]
+    fn build_get_revoc_reg_without_version_time(request_builder: RequestBuilder) {
+        let now = OffsetDateTime::now_utc().unix_timestamp();
+
+        let did_url_as_str = "did:indy:idunion:Dk1fRRTtNazyMuK2cr64wp/anoncreds/v0/REV_REG_ENTRY/104/revocable/a4e25e54";
+        let did_url = DidUrl::from_str(did_url_as_str).unwrap();
+        let request = build_request(&did_url, &request_builder).unwrap();
+        let timestamp = (*(request.req_json).get("operation").unwrap())
+            .get("timestamp")
+            .unwrap()
+            .as_u64()
+            .unwrap() as i64;
+
+        assert_eq!(constants::GET_REVOC_REG, request.txn_type);
+        assert!(timestamp >= now);
+    }
+
+    #[rstest]
+    fn build_get_revoc_reg_request_fails_with_unparsable_version_time(
+        request_builder: RequestBuilder,
+    ) {
+        let datetime_as_str = "20201220T19:17:47Z";
+        let did_url_as_str = format!("did:indy:idunion:Dk1fRRTtNazyMuK2cr64wp/anoncreds/v0/REV_REG_ENTRY/104/revocable/a4e25e54?versionTime={}",datetime_as_str);
+        let did_url = DidUrl::from_str(&did_url_as_str).unwrap();
+        let _err = build_request(&did_url, &request_builder).unwrap_err();
+    }
+
+    #[rstest]
+    fn build_get_revoc_reg_delta_request_with_from_to(request_builder: RequestBuilder) {
+        let from_as_str = "2019-12-20T19:17:47Z";
+        let to_as_str = "2020-12-20T19:17:47Z";
+        let did_url_as_str = format!("did:indy:idunion:Dk1fRRTtNazyMuK2cr64wp/anoncreds/v0/REV_REG_ENTRY/104/revocable/a4e25e54?from={}&to={}",from_as_str, to_as_str);
+        let did_url = DidUrl::from_str(&did_url_as_str).unwrap();
+        let request = build_request(&did_url, &request_builder).unwrap();
+        assert_eq!(request.txn_type, constants::GET_REVOC_REG_DELTA);
+    }
+
+    #[rstest]
+    fn build_get_revoc_reg_delta_request_with_from_only(request_builder: RequestBuilder) {
+        let now = OffsetDateTime::now_utc().unix_timestamp();
+        let from_as_str = "2019-12-20T19:17:47Z";
+        let did_url_as_str = format!("did:indy:idunion:Dk1fRRTtNazyMuK2cr64wp/anoncreds/v0/REV_REG_ENTRY/104/revocable/a4e25e54?from={}",from_as_str);
+        let did_url = DidUrl::from_str(&did_url_as_str).unwrap();
+        let request = build_request(&did_url, &request_builder).unwrap();
+
+        let to = (*(request.req_json).get("operation").unwrap())
+            .get("to")
+            .unwrap()
+            .as_u64()
+            .unwrap() as i64;
+        assert_eq!(request.txn_type, constants::GET_REVOC_REG_DELTA);
+        assert!(to >= now)
+    }
+
+    #[rstest]
+    fn build_get_revoc_reg_delta_request_without_parameter(request_builder: RequestBuilder) {
+        let now = OffsetDateTime::now_utc().unix_timestamp();
+        let did_url_as_str = "did:indy:idunion:Dk1fRRTtNazyMuK2cr64wp/anoncreds/v0/REV_REG_DELTA/104/revocable/a4e25e54";
+        let did_url = DidUrl::from_str(did_url_as_str).unwrap();
+        let request = build_request(&did_url, &request_builder).unwrap();
+
+        let to = (*(request.req_json).get("operation").unwrap())
+            .get("to")
+            .unwrap()
+            .as_u64()
+            .unwrap() as i64;
+
+        let from = (*(request.req_json).get("operation").unwrap()).get("from");
+        assert_eq!(request.txn_type, constants::GET_REVOC_REG_DELTA);
+        assert!(from.is_none());
+        assert!(to >= now);
+    }
+
+    #[rstest]
+    fn build_get_schema_request_with_whitespace(request_builder: RequestBuilder) {
+        let name = "My Schema";
+        let encoded_schema_name = encode(name).to_string();
+        let did_url_string = format!(
+            "did:indy:idunion:Dk1fRRTtNazyMuK2cr64wp/anoncreds/v0/SCHEMA/{}/1.0",
+            encoded_schema_name
+        );
+
+        let did_url = DidUrl::from_str(did_url_string.as_str()).unwrap();
+        let request = build_request(&did_url, &request_builder).unwrap();
+        let schema_name = (*(request.req_json).get("operation").unwrap())
+            .get("data")
+            .and_then(|v| v.get("name"))
+            .and_then(|v| v.as_str())
+            .unwrap();
+        assert_eq!(schema_name, name);
     }
 }

--- a/libindy_vdr/src/resolver/utils.rs
+++ b/libindy_vdr/src/resolver/utils.rs
@@ -16,8 +16,6 @@ use crate::pool::{Pool, PoolRunner, PreparedRequest, RequestResult, TimingResult
 use crate::utils::did::DidValue;
 use crate::utils::Qualifiable;
 
-pub type Callback<R> = Box<dyn (FnOnce(R) -> ()) + Send>;
-
 pub fn build_request(did: &DidUrl, builder: &RequestBuilder) -> VdrResult<PreparedRequest> {
     let request = if did.path.is_some() {
         match LedgerObject::from_str(did.path.as_ref().unwrap().as_str())? {
@@ -156,7 +154,7 @@ pub fn build_request(did: &DidUrl, builder: &RequestBuilder) -> VdrResult<Prepar
 }
 
 pub fn handle_resolution_result(
-    did_url: &DidUrl,
+    namespace: &str,
     ledger_data: &str,
     txn_type: &str,
 ) -> VdrResult<(Result, Metadata)> {
@@ -167,7 +165,7 @@ pub fn handle_resolution_result(
                 .map_err(|_| err_msg(VdrErrorKind::Resolver, "Could not parse NYM data"))?;
 
             let did_document = DidDocument::new(
-                &did_url.namespace,
+                namespace,
                 &get_nym_result.dest,
                 &get_nym_result.verkey,
                 None,

--- a/libindy_vdr/src/resolver/utils.rs
+++ b/libindy_vdr/src/resolver/utils.rs
@@ -1,0 +1,177 @@
+use serde_json::Value as SJsonValue;
+use time::format_description::well_known::Rfc3339;
+use time::OffsetDateTime;
+
+use super::did::{DidUrl, LedgerObject, QueryParameter};
+
+use crate::common::error::prelude::*;
+use crate::ledger::identifiers::{CredentialDefinitionId, RevocationRegistryId, SchemaId};
+use crate::ledger::RequestBuilder;
+use crate::pool::PreparedRequest;
+use crate::utils::Qualifiable;
+
+pub fn build_request(did: &DidUrl, builder: &RequestBuilder) -> VdrResult<PreparedRequest> {
+    let request = if did.path.is_some() {
+        match LedgerObject::from_str(did.path.as_ref().unwrap().as_str())? {
+            LedgerObject::Schema(schema) => builder.build_get_schema_request(
+                None,
+                &SchemaId::new(&did.id, &schema.name, &schema.version),
+            ),
+            LedgerObject::ClaimDef(claim_def) => builder.build_get_cred_def_request(
+                None,
+                &CredentialDefinitionId::from_str(
+                    format!(
+                        "{}:3:CL:{}:{}",
+                        &did.id, claim_def.schema_seq_no, claim_def.name
+                    )
+                    .as_str(),
+                )
+                .unwrap(),
+            ),
+            LedgerObject::RevRegDef(rev_reg_def) => builder.build_get_revoc_reg_def_request(
+                None,
+                &RevocationRegistryId::from_str(
+                    format!(
+                        "{}:4:{}:3:CL:{}:{}:CL_ACCUM:{}",
+                        &did.id,
+                        &did.id,
+                        rev_reg_def.schema_seq_no,
+                        rev_reg_def.claim_def_name,
+                        rev_reg_def.tag
+                    )
+                    .as_str(),
+                )
+                .unwrap(),
+            ),
+            LedgerObject::RevRegEntry(rev_reg_entry) => {
+                // If From or To parameters, return RevRegDelta request
+                if did.query.contains_key(&QueryParameter::From)
+                    || did.query.contains_key(&QueryParameter::To)
+                {
+                    let mut from: Option<i64> = None;
+                    if did.query.contains_key(&QueryParameter::From) {
+                        from = did
+                            .query
+                            .get(&QueryParameter::From)
+                            .and_then(|d| OffsetDateTime::parse(d, &Rfc3339).ok())
+                            .and_then(|d| Some(d.unix_timestamp()));
+                    }
+
+                    let to = parse_or_now(did.query.get(&QueryParameter::To))?;
+
+                    builder.build_get_revoc_reg_delta_request(
+                        None,
+                        &RevocationRegistryId::from_str(
+                            format!(
+                                "{}:4:{}:3:CL:{}:{}:CL_ACCUM:{}",
+                                &did.id,
+                                &did.id,
+                                rev_reg_entry.schema_seq_no,
+                                rev_reg_entry.claim_def_name,
+                                rev_reg_entry.tag
+                            )
+                            .as_str(),
+                        )
+                        .unwrap(),
+                        from,
+                        to,
+                    )
+                // Else return RevRegEntry request
+                } else {
+                    let timestamp = parse_or_now(did.query.get(&QueryParameter::VersionTime))?;
+
+                    builder.build_get_revoc_reg_request(
+                        None,
+                        &RevocationRegistryId::from_str(
+                            format!(
+                                "{}:4:{}:3:CL:{}:{}:CL_ACCUM:{}",
+                                &did.id,
+                                &did.id,
+                                rev_reg_entry.schema_seq_no,
+                                rev_reg_entry.claim_def_name,
+                                rev_reg_entry.tag
+                            )
+                            .as_str(),
+                        )
+                        .unwrap(),
+                        timestamp,
+                    )
+                }
+            }
+            // This path is deprecated. Deltas can be retrieved through RevRegEntry
+            LedgerObject::RevRegDelta(rev_reg_delta) => {
+                let mut from: Option<i64> = None;
+                if did.query.contains_key(&QueryParameter::From) {
+                    from = did
+                        .query
+                        .get(&QueryParameter::From)
+                        .and_then(|d| OffsetDateTime::parse(d, &Rfc3339).ok())
+                        .and_then(|d| Some(d.unix_timestamp()));
+                }
+
+                let to = parse_or_now(did.query.get(&QueryParameter::To))?;
+
+                builder.build_get_revoc_reg_delta_request(
+                    None,
+                    &RevocationRegistryId::from_str(
+                        format!(
+                            "{}:4:{}:3:CL:{}:{}:CL_ACCUM:{}",
+                            &did.id,
+                            &did.id,
+                            rev_reg_delta.schema_seq_no,
+                            rev_reg_delta.claim_def_name,
+                            rev_reg_delta.tag
+                        )
+                        .as_str(),
+                    )
+                    .unwrap(),
+                    from,
+                    to,
+                )
+            }
+        }
+    } else {
+        let seq_no: Option<i32> = did
+            .query
+            .get(&QueryParameter::VersionId)
+            .and_then(|v| v.parse().ok());
+        let timestamp: Option<u64> = did
+            .query
+            .get(&QueryParameter::VersionTime)
+            .and_then(|d| OffsetDateTime::parse(d, &Rfc3339).ok())
+            .and_then(|d| Some(d.unix_timestamp()))
+            .and_then(|d| Some(d as u64));
+
+        builder.build_get_nym_request(Option::None, &did.id, seq_no, timestamp)
+    };
+    request
+}
+
+pub fn parse_ledger_data(ledger_data: &str) -> VdrResult<SJsonValue> {
+    let v: SJsonValue = serde_json::from_str(&ledger_data)
+        .map_err(|_| err_msg(VdrErrorKind::Resolver, "Could not parse ledger response"))?;
+    let data: &SJsonValue = &v["result"]["data"];
+    if *data == SJsonValue::Null {
+        Err(err_msg(
+            VdrErrorKind::Resolver,
+            format!("Empty data in ledger response"),
+        ))
+    } else {
+        Ok(data.to_owned())
+    }
+}
+
+pub fn parse_or_now(datetime: Option<&String>) -> VdrResult<i64> {
+    match datetime {
+        Some(datetime) => {
+            let dt = OffsetDateTime::parse(datetime, &Rfc3339).map_err(|_| {
+                err_msg(
+                    VdrErrorKind::Resolver,
+                    format!("Could not parse datetime {}", datetime),
+                )
+            })?;
+            Ok(dt.unix_timestamp())
+        }
+        None => Ok(OffsetDateTime::now_utc().unix_timestamp()),
+    }
+}

--- a/libindy_vdr/src/resolver/utils.rs
+++ b/libindy_vdr/src/resolver/utils.rs
@@ -4,7 +4,7 @@ use time::OffsetDateTime;
 
 use super::did::{DidUrl, LedgerObject, QueryParameter};
 use super::did_document::{DidDocument, LEGACY_INDY_SERVICE};
-use super::resolver::*;
+use super::types::*;
 
 use crate::common::error::prelude::*;
 use crate::ledger::constants;

--- a/libindy_vdr/src/vdr/mod.rs
+++ b/libindy_vdr/src/vdr/mod.rs
@@ -1,4 +1,6 @@
 /// Indy VDR implementation for multiple ledgers and DID resolution/derefrence support
 mod vdr;
 
+pub mod utils;
+
 pub use self::vdr::{RunnerVdr, Vdr};

--- a/libindy_vdr/src/vdr/mod.rs
+++ b/libindy_vdr/src/vdr/mod.rs
@@ -1,4 +1,4 @@
 /// Indy VDR implementation for multiple ledgers and DID resolution/derefrence support
 mod vdr;
 
-pub use self::vdr::Vdr;
+pub use self::vdr::{RunnerVdr, Vdr};

--- a/libindy_vdr/src/vdr/mod.rs
+++ b/libindy_vdr/src/vdr/mod.rs
@@ -1,0 +1,4 @@
+/// Indy VDR implementation for multiple ledgers and DID resolution/derefrence support
+mod vdr;
+
+pub use self::vdr::Vdr;

--- a/libindy_vdr/src/vdr/utils.rs
+++ b/libindy_vdr/src/vdr/utils.rs
@@ -1,0 +1,72 @@
+use std::collections::HashMap;
+use std::fs;
+use std::path::PathBuf;
+
+use crate::{common::error::prelude::*, config::PoolConfig, pool::PoolTransactions};
+
+use super::vdr::{PoolTxnAndConfig, GENESIS_FILENAME};
+
+#[cfg(feature = "git")]
+use git2::Repository;
+
+#[cfg(feature = "git")]
+pub fn clone_repo(repo_url: &str) -> VdrResult<Repository> {
+    Repository::clone(repo_url, "github")
+        .map_err(|_err| err_msg(VdrErrorKind::Unexpected, "Could not clone networks repo"))
+}
+
+pub fn folder_to_networks(
+    path: PathBuf,
+    genesis_filename: Option<&str>,
+    default_config: Option<PoolConfig>,
+) -> VdrResult<HashMap<String, PoolTxnAndConfig>> {
+    let mut networks = HashMap::new();
+
+    let genesis_filename = genesis_filename.or(Some(GENESIS_FILENAME)).unwrap();
+
+    let entries = fs::read_dir(path).map_err(|err| {
+        err_msg(
+            VdrErrorKind::FileSystem(err),
+            "Could not read local networks folder",
+        )
+    })?;
+
+    for entry in entries {
+        let entry = entry.unwrap();
+        // filter hidden directories starting with "." and files
+        if !entry.file_name().to_str().unwrap().starts_with(".")
+            && entry.metadata().unwrap().is_dir()
+        {
+            let namespace = entry.path().file_name().unwrap().to_owned();
+            let sub_entries = fs::read_dir(entry.path()).unwrap();
+            for sub_entry in sub_entries {
+                let sub_entry_path = sub_entry.unwrap().path();
+                let sub_namespace = if sub_entry_path.is_dir() {
+                    sub_entry_path.file_name()
+                } else {
+                    None
+                };
+                let (ledger_prefix, genesis_txns) = match sub_namespace {
+                    Some(sub_namespace) => (
+                        format!(
+                            "{}:{}",
+                            namespace.to_str().unwrap(),
+                            sub_namespace.to_str().unwrap()
+                        ),
+                        PoolTransactions::from_json_file(sub_entry_path.join(genesis_filename))?,
+                    ),
+                    None => (
+                        String::from(namespace.to_str().unwrap()),
+                        PoolTransactions::from_json_file(entry.path().join(genesis_filename))?,
+                    ),
+                };
+                let cfg = PoolTxnAndConfig {
+                    txn: genesis_txns,
+                    config: default_config.clone(),
+                };
+                networks.insert(ledger_prefix, cfg);
+            }
+        }
+    }
+    Ok(networks)
+}

--- a/libindy_vdr/src/vdr/vdr.rs
+++ b/libindy_vdr/src/vdr/vdr.rs
@@ -475,21 +475,39 @@ impl RunnerVdr {
                                     //         }),
                                     //     );
                                 } else {
-                                    let diddoc = Some(doc.to_value().unwrap());
-                                    let md = if let Metadata::DidDocumentMetadata(md) = metadata {
-                                        Some(md)
-                                    } else {
-                                        None
-                                    };
+                                    // let diddoc = Some(doc.to_value().unwrap());
+                                    // let md = if let Metadata::DidDocumentMetadata(md) = metadata {
+                                    //     Some(md)
+                                    // } else {
+                                    //     None
+                                    // };
 
-                                    let result = ResolutionResult {
-                                        did_resolution_metadata: None,
-                                        did_document: diddoc,
-                                        did_document_metadata: md,
-                                    };
-                                    if !doc.diddoc_content.is_none() {
-                                        callback(Ok(serde_json::to_string_pretty(&result).unwrap()))
-                                    }
+                                    // let result = ResolutionResult {
+                                    //     did_resolution_metadata: None,
+                                    //     did_document: diddoc,
+                                    //     did_document_metadata: md,
+                                    // };
+                                    // if !doc.diddoc_content.is_none() {
+                                    //     callback(Ok(serde_json::to_string_pretty(&result).unwrap()))
+                                    // }
+                                }
+
+                                // For now, until if/else above is used
+
+                                let diddoc = Some(doc.to_value().unwrap());
+                                let md = if let Metadata::DidDocumentMetadata(md) = metadata {
+                                    Some(md)
+                                } else {
+                                    None
+                                };
+
+                                let result = ResolutionResult {
+                                    did_resolution_metadata: None,
+                                    did_document: diddoc,
+                                    did_document_metadata: md,
+                                };
+                                if !doc.diddoc_content.is_none() {
+                                    callback(Ok(serde_json::to_string_pretty(&result).unwrap()))
                                 }
                             }
                             _ => {}

--- a/libindy_vdr/src/vdr/vdr.rs
+++ b/libindy_vdr/src/vdr/vdr.rs
@@ -6,15 +6,15 @@ use std::fs;
 use std::path::PathBuf;
 
 use crate::common::error::prelude::*;
-use crate::ledger::responses::Endpoint;
+use crate::ledger::RequestBuilder;
 use crate::pool::genesis::PoolTransactions;
 use crate::pool::helpers::{perform_ledger_request, perform_refresh};
-use crate::pool::{Pool, PoolBuilder, PreparedRequest, RequestResult, SharedPool, TimingResult};
+use crate::pool::{
+    Pool, PoolBuilder, PoolRunner, PreparedRequest, RequestResult, SharedPool, TimingResult,
+};
 use crate::resolver::did::DidUrl;
-use crate::resolver::did_document::LEGACY_INDY_SERVICE;
 use crate::resolver::resolver::*;
 use crate::resolver::utils::*;
-use crate::utils::did::DidValue;
 
 const INDY_NETWORKS_GITHUB: &str = "https://github.com/IDunion/indy-did-networks";
 const GENESIS_FILENAME: &str = "pool_transactions_genesis.json";
@@ -174,7 +174,7 @@ impl Vdr {
 
         let diddoc = match data {
             Result::DidDocument(mut doc) => {
-                // Try to find legacy endpoint if diddoc_content is none
+                // Try to find legacy endpoint using a GET_ATTRIB txn if diddoc_content is none
                 if doc.diddoc_content.is_none() {
                     let pool = self
                         .pools
@@ -250,7 +250,6 @@ impl Vdr {
             .get_mut(namespace)
             .ok_or("Unkown namespace")
             .map_err(|err| err_msg(VdrErrorKind::Resolver, err))?;
-
         let (txns, _) = perform_refresh(pool).await?;
         let p = if let Some(txns) = txns {
             let builder = {
@@ -270,34 +269,316 @@ impl Vdr {
     }
 }
 
-async fn handle_request(pool: &SharedPool, request: &PreparedRequest) -> VdrResult<String> {
-    let (result, _timing) = request_transaction(pool, &request).await?;
-    match result {
-        RequestResult::Reply(data) => Ok(data),
-        RequestResult::Failed(error) => Err(error),
+pub struct RunnerVdr {
+    pools: HashMap<String, PoolRunner>,
+}
+
+impl RunnerVdr {
+    /// Expects a path to a folder with the following structure:
+    /// <namespace>/<sub-namespace>/<genesis_file_name>
+    /// Default for genesis_filename is pool_transactions_genesis.json
+    /// Example: sovrin/staging/pool_transactions_genesis.json
+    pub fn from_folder(path: PathBuf, genesis_filename: Option<&str>) -> VdrResult<RunnerVdr> {
+        debug!("Loading networks from local folder: {:?}", path);
+
+        let mut networks = HashMap::new();
+
+        let genesis_filename = genesis_filename.or(Some(GENESIS_FILENAME)).unwrap();
+
+        let entries = fs::read_dir(path).map_err(|err| {
+            err_msg(
+                VdrErrorKind::FileSystem(err),
+                "Could not read local networks folder",
+            )
+        })?;
+
+        for entry in entries {
+            let entry = entry.unwrap();
+            // filter hidden directories starting with "." and files
+            if !entry.file_name().to_str().unwrap().starts_with(".")
+                && entry.metadata().unwrap().is_dir()
+            {
+                let namespace = entry.path().file_name().unwrap().to_owned();
+                let sub_entries = fs::read_dir(entry.path()).unwrap();
+                for sub_entry in sub_entries {
+                    let sub_entry_path = sub_entry.unwrap().path();
+                    let sub_namespace = if sub_entry_path.is_dir() {
+                        sub_entry_path.file_name()
+                    } else {
+                        None
+                    };
+                    let (ledger_prefix, genesis_txns) = match sub_namespace {
+                        Some(sub_namespace) => (
+                            format!(
+                                "{}:{}",
+                                namespace.to_str().unwrap(),
+                                sub_namespace.to_str().unwrap()
+                            ),
+                            PoolTransactions::from_json_file(
+                                sub_entry_path.join(genesis_filename),
+                            )?,
+                        ),
+                        None => (
+                            String::from(namespace.to_str().unwrap()),
+                            PoolTransactions::from_json_file(entry.path().join(genesis_filename))?,
+                        ),
+                    };
+                    networks.insert(ledger_prefix, genesis_txns);
+                }
+            }
+        }
+        RunnerVdr::new(networks)
     }
-}
 
-async fn request_transaction(
-    pool: &SharedPool,
-    request: &PreparedRequest,
-) -> VdrResult<(RequestResult<String>, Option<TimingResult>)> {
-    perform_ledger_request(pool, &request).await
-}
+    /// Initialize VDR from a GitHub repo containing Indy network genesis files
+    /// Default repo is https://github.com/IDunion/indy-did-networks
+    pub fn from_github(repo_url: Option<&str>) -> VdrResult<RunnerVdr> {
+        let repo_url = repo_url.or(Some(INDY_NETWORKS_GITHUB)).unwrap();
+        debug!("Obtaining network information from {}", repo_url);
+        // Delete folder if it exists and reclone repo
+        fs::remove_dir_all("github").ok();
+        let repo = Repository::clone(INDY_NETWORKS_GITHUB, "github")
+            .map_err(|_err| err_msg(VdrErrorKind::Unexpected, "Could not clone networks repo"))?;
 
-/// Fetch legacy service endpoint using ATTRIB tx
-async fn fetch_legacy_endpoint(pool: &SharedPool, did: &DidValue) -> VdrResult<Endpoint> {
-    let builder = pool.get_request_builder();
-    let request = builder.build_get_attrib_request(
-        None,
-        did,
-        Some(String::from(LEGACY_INDY_SERVICE)),
-        None,
-        None,
-    )?;
-    let ledger_data = handle_request(pool, &request).await?;
-    let endpoint_data = parse_ledger_data(&ledger_data)?;
-    let endpoint_data: Endpoint = serde_json::from_str(endpoint_data.as_str().unwrap())
-        .map_err(|_| err_msg(VdrErrorKind::Resolver, "Could not parse endpoint data"))?;
-    Ok(endpoint_data)
+        let path = repo.path().parent().unwrap().to_owned();
+
+        RunnerVdr::from_folder(path, None)
+    }
+
+    /// Create a new VDR instance from a map of namespaces and genesis transactions
+    pub fn new(networks: HashMap<String, PoolTransactions>) -> VdrResult<RunnerVdr> {
+        let mut pools = HashMap::new();
+
+        for (namespace, txns) in networks {
+            let pool_builder = PoolBuilder::default().transactions(txns.to_owned())?;
+            let pool = pool_builder.into_runner()?;
+            pools.insert(namespace.to_string(), pool);
+        }
+
+        Ok(RunnerVdr { pools })
+    }
+
+    /// Add a new ledger to the VDR
+    pub fn add_ledger(&mut self, namespace: &str, pool: PoolRunner) {
+        self.pools.insert(String::from(namespace), pool);
+    }
+
+    /// Remove a ledger from the VDR
+    pub fn remove_ledger(&mut self, namespace: &str) {
+        self.pools.remove(namespace);
+    }
+
+    /// Get names of all ledgers
+    pub fn get_ledgers(&self) -> VdrResult<Vec<String>> {
+        Ok(self.pools.keys().cloned().collect::<Vec<String>>())
+    }
+
+    /// Get a validator pool reference
+    pub fn get_pool(&self, namespace: &str) -> Option<&PoolRunner> {
+        self.borrow().pools.get(namespace)
+    }
+    /// Send a prepared request to a specific network
+    // pub async fn send_request(
+    //     &self,
+    //     namespace: &str,
+    //     req: PreparedRequest,
+    // ) -> VdrResult<(RequestResult<String>, Option<TimingResult>)> {
+    //     let pool = self
+    //         .pools
+    //         .get(namespace)
+    //         .ok_or(err_msg(VdrErrorKind::Resolver, "Unkown namespace"))?;
+    //     perform_ledger_request(pool, &req).await
+    // }
+
+    /// Dereference a DID Url and return a serialized `DereferencingResult`
+    pub fn dereference(
+        &self,
+        did_url: &str,
+        callback: Callback<VdrResult<String>>,
+    ) -> VdrResult<()> {
+        debug!("VDR: Dereference DID Url {}", did_url);
+        let did_url = DidUrl::from_str(did_url)?;
+        self._resolve(
+            did_url,
+            Box::new(|result| {
+                match result {
+                    Ok((data, metadata)) => {
+                        let content = match data {
+                            Result::Content(c) => Some(c),
+                            _ => None,
+                        };
+
+                        let md = if let Metadata::ContentMetadata(md) = metadata {
+                            Some(md)
+                        } else {
+                            None
+                        };
+
+                        let result = DereferencingResult {
+                            dereferencing_metadata: None,
+                            content_stream: content,
+                            content_metadata: md,
+                        };
+
+                        callback(Ok(serde_json::to_string_pretty(&result).unwrap()));
+                    }
+                    // TODO: How to handle errors?
+                    Err(_err) => {}
+                }
+            }),
+        )?;
+        Ok(())
+    }
+
+    /// Resolve a DID and return a serialized `ResolutionResult`
+    pub fn resolve(&self, did: &str, callback: Callback<VdrResult<String>>) -> VdrResult<()> {
+        debug!("VDR Resolve DID {}", did);
+        let did = DidUrl::from_str(did)?;
+        self._resolve(
+            did,
+            Box::new(|result| {
+                match result {
+                    Ok((data, metadata)) => {
+                        match data {
+                            // TODO: Doc needs to be mutable, when we uncomment
+                            Result::DidDocument(doc) => {
+                                // Try to find legacy endpoint using a GET_ATTRIB txn if diddoc_content is none
+                                if doc.diddoc_content.is_none() {
+                                    //     let pool = self
+                                    //         .pools
+                                    //         .get(&did.namespace)
+                                    //         .ok_or(err_msg(VdrErrorKind::Resolver, "Unkown namespace"))
+                                    //         .unwrap();
+                                    //     fetch_legacy_endpoint_with_runner(
+                                    //         pool,
+                                    //         &did.id,
+                                    //         Box::new(|result| {
+                                    //             doc.endpoint = result.ok();
+                                    //             let diddoc = Some(doc.to_value().unwrap());
+                                    //             let md = if let Metadata::DidDocumentMetadata(md) =
+                                    //                 metadata
+                                    //             {
+                                    //                 Some(md)
+                                    //             } else {
+                                    //                 None
+                                    //             };
+
+                                    //             let result = ResolutionResult {
+                                    //                 did_resolution_metadata: None,
+                                    //                 did_document: diddoc,
+                                    //                 did_document_metadata: md,
+                                    //             };
+
+                                    //             callback(Ok(
+                                    //                 serde_json::to_string_pretty(&result).unwrap()
+                                    //             ))
+                                    //         }),
+                                    //     );
+                                } else {
+                                    let diddoc = Some(doc.to_value().unwrap());
+                                    let md = if let Metadata::DidDocumentMetadata(md) = metadata {
+                                        Some(md)
+                                    } else {
+                                        None
+                                    };
+
+                                    let result = ResolutionResult {
+                                        did_resolution_metadata: None,
+                                        did_document: diddoc,
+                                        did_document_metadata: md,
+                                    };
+                                    if !doc.diddoc_content.is_none() {
+                                        callback(Ok(serde_json::to_string_pretty(&result).unwrap()))
+                                    }
+                                }
+                            }
+                            _ => {}
+                        };
+                    }
+                    // TODO: How to handle errors?
+                    Err(_err) => {}
+                }
+            }),
+        )?;
+        Ok(())
+    }
+
+    // Internal method to resolve and dereference
+    fn _resolve(
+        &self,
+        did_url: DidUrl,
+        callback: Callback<VdrResult<(Result, Metadata)>>,
+    ) -> VdrResult<()> {
+        let runner = self
+            .pools
+            .get(&did_url.namespace)
+            .ok_or(err_msg(VdrErrorKind::Resolver, "Unkown namespace"))?;
+
+        let builder = RequestBuilder::default();
+        let request = build_request(&did_url, &builder)?;
+
+        let txn_type = request.txn_type.to_owned();
+
+        runner.send_request(
+            request,
+            Box::new(
+                move |result: VdrResult<(RequestResult<String>, Option<TimingResult>)>| {
+                    let ledger_data = match result {
+                        Ok((reply, _)) => match reply {
+                            RequestResult::Reply(reply_data) => Ok(reply_data),
+                            RequestResult::Failed(err) => Err(err),
+                        },
+                        Err(err) => Err(err),
+                    }
+                    .unwrap();
+
+                    let result =
+                        handle_resolution_result(&did_url, &ledger_data, txn_type.as_str())
+                            .unwrap();
+                    callback(Ok(result))
+                },
+            ),
+        )
+    }
+
+    // Refresh validator pools for all networks
+    // pub async fn refresh_all(&mut self) -> VdrResult<()> {
+    //     let keys: Vec<String> = self.pools.keys().cloned().collect();
+
+    //     for k in keys.iter() {
+    //         let pool = self.pools.get_mut(k).unwrap();
+    //         let (txns, _) = perform_refresh(pool).await?;
+    //         let p = if let Some(txns) = txns {
+    //             let builder = {
+    //                 let mut current_txns =
+    //                     PoolTransactions::from_json_transactions(pool.get_json_transactions()?)
+    //                         .unwrap();
+    //                 current_txns.extend_from_json(&txns)?;
+    //                 PoolBuilder::default().transactions(current_txns.clone())?
+    //             };
+    //             builder.into_shared()?
+    //         } else {
+    //             pool.to_owned()
+    //         };
+    //         *pool = p;
+    //     }
+    //     Ok(())
+    // }
+
+    /// Refresh the validator pool of a particular network
+    pub fn refresh(
+        &mut self,
+        namespace: &str,
+        callback: Callback<VdrResult<(Vec<String>, Option<Vec<String>>, Option<TimingResult>)>>,
+    ) -> VdrResult<()> {
+        let runner = self
+            .pools
+            .get_mut(namespace)
+            .ok_or("Unkown namespace")
+            .map_err(|err| err_msg(VdrErrorKind::Resolver, err))?;
+
+        runner.refresh(callback)?;
+
+        Ok(())
+    }
 }

--- a/libindy_vdr/src/vdr/vdr.rs
+++ b/libindy_vdr/src/vdr/vdr.rs
@@ -213,8 +213,9 @@ impl Vdr {
         let request = build_request(&did_url, &builder)?;
 
         let ledger_data = handle_request(pool, &request).await?;
-        let txn_type = &request.txn_type.as_str();
-        let result = handle_resolution_result(&did_url, &ledger_data, txn_type)?;
+        let txn_type = request.txn_type.as_str();
+        let namespace = did_url.namespace.clone();
+        let result = handle_resolution_result(namespace.as_str(), &ledger_data, txn_type)?;
 
         Ok(result)
     }
@@ -550,9 +551,14 @@ impl RunnerVdr {
                     }
                     .unwrap();
 
-                    let result =
-                        handle_resolution_result(&did_url, &ledger_data, txn_type.as_str())
-                            .unwrap();
+                    let namespace = did_url.namespace.clone();
+
+                    let result = handle_resolution_result(
+                        namespace.as_str(),
+                        &ledger_data,
+                        txn_type.as_str(),
+                    )
+                    .unwrap();
                     callback(Ok(result))
                 },
             ),

--- a/libindy_vdr/src/vdr/vdr.rs
+++ b/libindy_vdr/src/vdr/vdr.rs
@@ -1,3 +1,4 @@
+#[cfg(feature = "git")]
 use git2::Repository;
 
 use std::borrow::Borrow;

--- a/libindy_vdr/src/vdr/vdr.rs
+++ b/libindy_vdr/src/vdr/vdr.rs
@@ -80,6 +80,7 @@ impl Vdr {
         Vdr::new(networks)
     }
 
+    #[cfg(feature = "git")]
     /// Initialize VDR from a GitHub repo containing Indy network genesis files
     /// Default repo is https://github.com/IDunion/indy-did-networks
     pub fn from_github(repo_url: Option<&str>) -> VdrResult<Vdr> {
@@ -331,6 +332,7 @@ impl RunnerVdr {
         RunnerVdr::new(networks)
     }
 
+    #[cfg(feature = "git")]
     /// Initialize VDR from a GitHub repo containing Indy network genesis files
     /// Default repo is https://github.com/IDunion/indy-did-networks
     pub fn from_github(repo_url: Option<&str>) -> VdrResult<RunnerVdr> {

--- a/libindy_vdr/src/vdr/vdr.rs
+++ b/libindy_vdr/src/vdr/vdr.rs
@@ -1,7 +1,7 @@
 #[cfg(feature = "git")]
 use git2::Repository;
 
-use std::borrow::Borrow;
+use std::borrow::{Borrow, BorrowMut};
 use std::collections::HashMap;
 use std::fs;
 use std::path::PathBuf;
@@ -382,6 +382,10 @@ impl RunnerVdr {
     pub fn get_pool(&self, namespace: &str) -> Option<&PoolRunner> {
         self.borrow().pools.get(namespace)
     }
+
+    pub fn set_pool(&mut self, namespace: String, pool: PoolRunner) {
+        self.borrow_mut().pools.insert(namespace, pool);
+    }
     /// Send a prepared request to a specific network
     // pub async fn send_request(
     //     &self,
@@ -566,46 +570,5 @@ impl RunnerVdr {
                 },
             ),
         )
-    }
-
-    // Refresh validator pools for all networks
-    // pub async fn refresh_all(&mut self) -> VdrResult<()> {
-    //     let keys: Vec<String> = self.pools.keys().cloned().collect();
-
-    //     for k in keys.iter() {
-    //         let pool = self.pools.get_mut(k).unwrap();
-    //         let (txns, _) = perform_refresh(pool).await?;
-    //         let p = if let Some(txns) = txns {
-    //             let builder = {
-    //                 let mut current_txns =
-    //                     PoolTransactions::from_json_transactions(pool.get_json_transactions()?)
-    //                         .unwrap();
-    //                 current_txns.extend_from_json(&txns)?;
-    //                 PoolBuilder::default().transactions(current_txns.clone())?
-    //             };
-    //             builder.into_shared()?
-    //         } else {
-    //             pool.to_owned()
-    //         };
-    //         *pool = p;
-    //     }
-    //     Ok(())
-    // }
-
-    /// Refresh the validator pool of a particular network
-    pub fn refresh(
-        &mut self,
-        namespace: &str,
-        callback: Callback<VdrResult<(Vec<String>, Option<Vec<String>>, Option<TimingResult>)>>,
-    ) -> VdrResult<()> {
-        let runner = self
-            .pools
-            .get_mut(namespace)
-            .ok_or("Unkown namespace")
-            .map_err(|err| err_msg(VdrErrorKind::Resolver, err))?;
-
-        runner.refresh(callback)?;
-
-        Ok(())
     }
 }

--- a/libindy_vdr/src/vdr/vdr.rs
+++ b/libindy_vdr/src/vdr/vdr.rs
@@ -13,7 +13,7 @@ use crate::pool::{
     Pool, PoolBuilder, PoolRunner, PreparedRequest, RequestResult, SharedPool, TimingResult,
 };
 use crate::resolver::did::DidUrl;
-use crate::resolver::resolver::*;
+use crate::resolver::types::*;
 use crate::resolver::utils::*;
 
 const INDY_NETWORKS_GITHUB: &str = "https://github.com/IDunion/indy-did-networks";

--- a/libindy_vdr/src/vdr/vdr.rs
+++ b/libindy_vdr/src/vdr/vdr.rs
@@ -1,0 +1,351 @@
+use git2::Repository;
+
+use std::collections::HashMap;
+use std::fs;
+use std::path::PathBuf;
+
+use crate::common::error::prelude::*;
+use crate::ledger::constants;
+use crate::ledger::responses::{Endpoint, GetNymResultV1};
+use crate::pool::genesis::PoolTransactions;
+use crate::pool::helpers::{perform_ledger_request, perform_refresh};
+use crate::pool::{Pool, PoolBuilder, PreparedRequest, RequestResult, SharedPool, TimingResult};
+use crate::resolver::did::DidUrl;
+use crate::resolver::did_document::{DidDocument, LEGACY_INDY_SERVICE};
+use crate::resolver::resolver::*;
+use crate::resolver::utils::*;
+use crate::utils::did::DidValue;
+
+const INDY_NETWORKS_GITHUB: &str = "https://github.com/IDunion/indy-did-networks";
+const GENESIS_FILENAME: &str = "pool_transactions_genesis.json";
+
+pub struct Vdr {
+    pools: HashMap<String, SharedPool>,
+}
+
+impl Vdr {
+    /// Expects a path to a folder with the following structure:
+    /// <namespace>/<sub-namespace>/<genesis_file_name>
+    /// Default for genesis_filename is pool_transactions_genesis.json
+    /// Example: sovrin/staging/pool_transactions_genesis.json
+    pub fn from_folder(path: PathBuf, genesis_filename: Option<&str>) -> VdrResult<Vdr> {
+        debug!("Loading networks from local folder: {:?}", path);
+
+        let mut networks = HashMap::new();
+
+        let genesis_filename = genesis_filename.or(Some(GENESIS_FILENAME)).unwrap();
+
+        let entries = fs::read_dir(path).map_err(|err| {
+            err_msg(
+                VdrErrorKind::FileSystem(err),
+                "Could not read local networks folder",
+            )
+        })?;
+
+        for entry in entries {
+            let entry = entry.unwrap();
+            // filter hidden directories starting with "." and files
+            if !entry.file_name().to_str().unwrap().starts_with(".")
+                && entry.metadata().unwrap().is_dir()
+            {
+                let namespace = entry.path().file_name().unwrap().to_owned();
+                let sub_entries = fs::read_dir(entry.path()).unwrap();
+                for sub_entry in sub_entries {
+                    let sub_entry_path = sub_entry.unwrap().path();
+                    let sub_namespace = if sub_entry_path.is_dir() {
+                        sub_entry_path.file_name()
+                    } else {
+                        None
+                    };
+                    let (ledger_prefix, genesis_txns) = match sub_namespace {
+                        Some(sub_namespace) => (
+                            format!(
+                                "{}:{}",
+                                namespace.to_str().unwrap(),
+                                sub_namespace.to_str().unwrap()
+                            ),
+                            PoolTransactions::from_json_file(
+                                sub_entry_path.join(genesis_filename),
+                            )?,
+                        ),
+                        None => (
+                            String::from(namespace.to_str().unwrap()),
+                            PoolTransactions::from_json_file(entry.path().join(genesis_filename))?,
+                        ),
+                    };
+                    networks.insert(ledger_prefix, genesis_txns);
+                }
+            }
+        }
+        Vdr::new(networks)
+    }
+    /// Initialize VDR from a GitHub repo containing Indy network genesis files
+    /// Default repo is https://github.com/IDunion/indy-did-networks
+    pub fn from_github(repo_url: Option<&str>) -> VdrResult<Vdr> {
+        let repo_url = repo_url.or(Some(INDY_NETWORKS_GITHUB)).unwrap();
+        debug!("Obtaining network information from {}", repo_url);
+        // Delete folder if it exists and reclone repo
+        fs::remove_dir_all("github").ok();
+        let repo = Repository::clone(INDY_NETWORKS_GITHUB, "github")
+            .map_err(|_err| err_msg(VdrErrorKind::Unexpected, "Could not clone networks repo"))?;
+
+        let path = repo.path().parent().unwrap().to_owned();
+
+        Vdr::from_folder(path, None)
+    }
+
+    /// Create a new VDR instance from a map of namespaces and genesis transactions
+    pub fn new(networks: HashMap<String, PoolTransactions>) -> VdrResult<Vdr> {
+        let mut pools = HashMap::new();
+
+        for (namespace, txns) in networks {
+            let pool_builder = PoolBuilder::default().transactions(txns.to_owned())?;
+            let pool = pool_builder.into_shared()?;
+            pools.insert(namespace.to_string(), pool);
+        }
+
+        Ok(Vdr { pools })
+    }
+
+    /// Add a new ledger to the VDR
+    pub fn add_ledger(mut self, namespace: String, pool: SharedPool) {
+        self.pools.insert(namespace, pool);
+    }
+
+    /// Remove a ledger from the VDR
+    pub fn remove_ledger(mut self, namespace: &str) {
+        self.pools.remove(namespace);
+    }
+
+    /// Send a prepared request to a specific network
+    pub async fn send_request(
+        self,
+        namespace: &str,
+        req: PreparedRequest,
+    ) -> VdrResult<(RequestResult<String>, Option<TimingResult>)> {
+        let pool = self
+            .pools
+            .get(namespace)
+            .ok_or(err_msg(VdrErrorKind::Resolver, "Unkown namespace"))?;
+        perform_ledger_request(pool, &req).await
+    }
+
+    /// Dereference a DID Url and return a serialized `DereferencingResult`
+    pub async fn dereference(&self, did_url: &str) -> VdrResult<String> {
+        debug!("PoolResolver: Dereference DID Url {}", did_url);
+        let (data, metadata) = self._resolve(did_url).await?;
+
+        let content = match data {
+            Result::Content(c) => Some(c),
+            _ => None,
+        };
+
+        let md = if let Metadata::ContentMetadata(md) = metadata {
+            Some(md)
+        } else {
+            None
+        };
+
+        let result = DereferencingResult {
+            dereferencing_metadata: None,
+            content_stream: content,
+            content_metadata: md,
+        };
+
+        Ok(serde_json::to_string_pretty(&result).unwrap())
+    }
+
+    /// Resolve a DID and return a serialized `ResolutionResult`
+    pub async fn resolve(&self, did: &str) -> VdrResult<String> {
+        debug!("PoolResolver: Resolve DID {}", did);
+        let (data, metadata) = self._resolve(did).await?;
+
+        let diddoc = match data {
+            Result::DidDocument(doc) => Some(doc.to_value()?),
+            _ => None,
+        };
+
+        let md = if let Metadata::DidDocumentMetadata(md) = metadata {
+            Some(md)
+        } else {
+            None
+        };
+
+        let result = ResolutionResult {
+            did_resolution_metadata: None,
+            did_document: diddoc,
+            did_document_metadata: md,
+        };
+
+        Ok(serde_json::to_string_pretty(&result).unwrap())
+    }
+
+    // Internal method to resolve and dereference
+    async fn _resolve(&self, did: &str) -> VdrResult<(Result, Metadata)> {
+        let did_url = DidUrl::from_str(did)?;
+        let pool = self
+            .pools
+            .get(&did_url.namespace)
+            .ok_or(err_msg(VdrErrorKind::Resolver, "Unkown namespace"))?;
+
+        let builder = pool.get_request_builder();
+        let request = build_request(&did_url, &builder)?;
+
+        let ledger_data = handle_request(pool, &request).await?;
+        let data = parse_ledger_data(&ledger_data)?;
+
+        let (result, metadata) = match request.txn_type.as_str() {
+            constants::GET_NYM => {
+                let get_nym_result: GetNymResultV1 =
+                    serde_json::from_str(data.as_str().unwrap())
+                        .map_err(|_| err_msg(VdrErrorKind::Resolver, "Could not parse NYM data"))?;
+
+                let endpoint: Option<Endpoint> = if get_nym_result.diddoc_content.is_none() {
+                    // Legacy: Try to find an attached ATTRIBUTE transacation with raw endpoint
+                    self.fetch_legacy_endpoint(pool, &did_url.id).await.ok()
+                } else {
+                    None
+                };
+
+                let did_document = DidDocument::new(
+                    &did_url.namespace,
+                    &get_nym_result.dest,
+                    &get_nym_result.verkey,
+                    endpoint,
+                    None,
+                );
+
+                let metadata = Metadata::DidDocumentMetadata(DidDocumentMetadata {
+                    node_response: serde_json::from_str(&ledger_data).unwrap(),
+                    object_type: String::from("NYM"),
+                    self_certification_version: get_nym_result.version,
+                });
+
+                (Result::DidDocument(did_document), metadata)
+            }
+            constants::GET_CRED_DEF => (
+                Result::Content(data),
+                Metadata::ContentMetadata(ContentMetadata {
+                    node_response: serde_json::from_str(&ledger_data).unwrap(),
+                    object_type: String::from("CRED_DEF"),
+                }),
+            ),
+            constants::GET_SCHEMA => (
+                Result::Content(data),
+                Metadata::ContentMetadata(ContentMetadata {
+                    node_response: serde_json::from_str(&ledger_data).unwrap(),
+                    object_type: String::from("SCHEMA"),
+                }),
+            ),
+            constants::GET_REVOC_REG_DEF => (
+                Result::Content(data),
+                Metadata::ContentMetadata(ContentMetadata {
+                    node_response: serde_json::from_str(&ledger_data).unwrap(),
+                    object_type: String::from("REVOC_REG_DEF"),
+                }),
+            ),
+            constants::GET_REVOC_REG_DELTA => (
+                Result::Content(data),
+                Metadata::ContentMetadata(ContentMetadata {
+                    node_response: serde_json::from_str(&ledger_data).unwrap(),
+                    object_type: String::from("REVOC_REG_DELTA"),
+                }),
+            ),
+            _ => (
+                Result::Content(data),
+                Metadata::ContentMetadata(ContentMetadata {
+                    node_response: serde_json::from_str(&ledger_data).unwrap(),
+                    object_type: String::from("REVOC_REG_DELTA"),
+                }),
+            ),
+        };
+
+        let result_with_metadata = (result, metadata);
+
+        Ok(result_with_metadata)
+    }
+
+    /// Fetch legacy service endpoint using ATTRIB tx
+    async fn fetch_legacy_endpoint(
+        &self,
+        pool: &SharedPool,
+        did: &DidValue,
+    ) -> VdrResult<Endpoint> {
+        let builder = pool.get_request_builder();
+        let request = builder.build_get_attrib_request(
+            None,
+            did,
+            Some(String::from(LEGACY_INDY_SERVICE)),
+            None,
+            None,
+        )?;
+        let ledger_data = handle_request(pool, &request).await?;
+        let endpoint_data = parse_ledger_data(&ledger_data)?;
+        let endpoint_data: Endpoint = serde_json::from_str(endpoint_data.as_str().unwrap())
+            .map_err(|_| err_msg(VdrErrorKind::Resolver, "Could not parse endpoint data"))?;
+        Ok(endpoint_data)
+    }
+
+    pub async fn refresh_all(mut self) -> VdrResult<()> {
+        let keys: Vec<String> = self.pools.keys().cloned().collect();
+
+        for k in keys.iter() {
+            let pool = self.pools.get_mut(k).unwrap();
+            let (txns, _) = perform_refresh(pool).await?;
+            let p = if let Some(txns) = txns {
+                let builder = {
+                    let mut current_txns =
+                        PoolTransactions::from_json_transactions(pool.get_json_transactions()?)
+                            .unwrap();
+                    current_txns.extend_from_json(&txns)?;
+                    PoolBuilder::default().transactions(current_txns.clone())?
+                };
+                builder.into_shared()?
+            } else {
+                pool.to_owned()
+            };
+            *pool = p;
+        }
+        Ok(())
+    }
+
+    pub async fn refresh(mut self, namespace: &str) -> VdrResult<()> {
+        let pool = self
+            .pools
+            .get_mut(namespace)
+            .ok_or("Unkown namespace")
+            .map_err(|err| err_msg(VdrErrorKind::Resolver, err))?;
+
+        let (txns, _) = perform_refresh(pool).await?;
+        let p = if let Some(txns) = txns {
+            let builder = {
+                let mut current_txns =
+                    PoolTransactions::from_json_transactions(pool.get_json_transactions()?)
+                        .unwrap();
+                current_txns.extend_from_json(&txns)?;
+                PoolBuilder::default().transactions(current_txns.clone())?
+            };
+            builder.into_shared()?
+        } else {
+            pool.to_owned()
+        };
+        *pool = p;
+
+        Ok(())
+    }
+}
+
+async fn handle_request(pool: &SharedPool, request: &PreparedRequest) -> VdrResult<String> {
+    let (result, _timing) = request_transaction(pool, &request).await?;
+    match result {
+        RequestResult::Reply(data) => Ok(data),
+        RequestResult::Failed(error) => Err(error),
+    }
+}
+
+async fn request_transaction(
+    pool: &SharedPool,
+    request: &PreparedRequest,
+) -> VdrResult<(RequestResult<String>, Option<TimingResult>)> {
+    perform_ledger_request(pool, &request).await
+}

--- a/libindy_vdr/src/vdr/vdr.rs
+++ b/libindy_vdr/src/vdr/vdr.rs
@@ -17,6 +17,7 @@ use crate::resolver::did::DidUrl;
 use crate::resolver::types::*;
 use crate::resolver::utils::*;
 
+#[cfg(feature = "git")]
 const INDY_NETWORKS_GITHUB: &str = "https://github.com/IDunion/indy-did-networks";
 const GENESIS_FILENAME: &str = "pool_transactions_genesis.json";
 
@@ -510,9 +511,8 @@ impl RunnerVdr {
                                     did_document: diddoc,
                                     did_document_metadata: md,
                                 };
-                                if !doc.diddoc_content.is_none() {
-                                    callback(Ok(serde_json::to_string_pretty(&result).unwrap()))
-                                }
+
+                                callback(Ok(serde_json::to_string_pretty(&result).unwrap()))
                             }
                             _ => {}
                         };

--- a/wrappers/python/demo/test.py
+++ b/wrappers/python/demo/test.py
@@ -191,6 +191,10 @@ async def basic_test(transactions_path):
     # doc = await vdr.resolve("did:indy:idunion:TUyWgaU7pCG4FQyvrXapf2")
     # log(json.dumps(doc, indent=2))
 
+    # Get connected ledgers
+    ledgers = vdr.get_ledgers()
+    log("Ledgers", ledgers)
+
     # req = build_rich_schema_request(
     #     None, "did:sov:some_hash", '{"some": 1}', "test", "version", "sch", "1.0.0"
     # )

--- a/wrappers/python/demo/test.py
+++ b/wrappers/python/demo/test.py
@@ -28,6 +28,8 @@ from indy_vdr.ledger import (
 from indy_vdr.pool import Pool, open_pool
 from indy_vdr.resolver import Resolver
 
+from indy_vdr.vdr import Vdr, init_from_github
+
 
 def log(*args):
     print(*args, "\n")
@@ -122,9 +124,9 @@ async def basic_test(transactions_path):
     
     log("Resolve DID did:indy:sovrin:XvSeT51zDWVTXatLWPknWb")
     resolver = Resolver(pool.handle)
-    doc = await resolver.resolve("did:indy:sovrin:XvSeT51zDWVTXatLWPknWb")
+    # doc = await resolver.resolve("did:indy:sovrin:XvSeT51zDWVTXatLWPknWb")
 
-    log(json.dumps(doc, indent=2))
+    # log(json.dumps(doc, indent=2))
 
 
     req = build_nym_request(
@@ -180,7 +182,13 @@ async def basic_test(transactions_path):
         1647602534, # timestamp
     )
 
-    log("GET_NYM request with timestamp", req.body) 
+    log("GET_NYM request with timestamp", req.body)
+
+
+    # Indy VDR with general indy DID resolution
+    vdr = init_from_github()
+    doc = await vdr.resolve("did:indy:idunion:TUyWgaU7pCG4FQyvrXapf2")
+    log(json.dumps(doc, indent=2))
 
     # req = build_rich_schema_request(
     #     None, "did:sov:some_hash", '{"some": 1}', "test", "version", "sch", "1.0.0"

--- a/wrappers/python/demo/test.py
+++ b/wrappers/python/demo/test.py
@@ -121,7 +121,9 @@ async def basic_test(transactions_path):
     req = build_get_revoc_reg_delta_request(None, revoc_id, from_ts=None, to_ts=1)
     log("Get revoc reg delta request:", req.body)
 
-    
+
+    # The pool resolver interface is bound to a specfic network anddoes not check the DID namespace
+    # The client has to take care of mapping the namespace to the correct pool resolver
     log("Resolve DID did:indy:sovrin:XvSeT51zDWVTXatLWPknWb")
     resolver = Resolver(pool.handle)
     # doc = await resolver.resolve("did:indy:sovrin:XvSeT51zDWVTXatLWPknWb")
@@ -192,8 +194,8 @@ async def basic_test(transactions_path):
     # log(json.dumps(doc, indent=2))
 
     # Get connected ledgers
-    ledgers = vdr.get_ledgers()
-    log("Ledgers", ledgers)
+    #ledgers = vdr.get_ledgers()
+    #log("Ledgers", ledgers)
 
     # req = build_rich_schema_request(
     #     None, "did:sov:some_hash", '{"some": 1}', "test", "version", "sch", "1.0.0"

--- a/wrappers/python/demo/test.py
+++ b/wrappers/python/demo/test.py
@@ -7,6 +7,8 @@ import urllib.request
 from indy_vdr.bindings import version
 from indy_vdr.ledger import (
     build_custom_request,
+    build_nym_request,
+    build_get_nym_request,
     build_get_txn_request,
     build_get_acceptance_mechanisms_request,
     build_get_txn_author_agreement_request,
@@ -117,11 +119,68 @@ async def basic_test(transactions_path):
     req = build_get_revoc_reg_delta_request(None, revoc_id, from_ts=None, to_ts=1)
     log("Get revoc reg delta request:", req.body)
 
+    
     log("Resolve DID did:indy:sovrin:XvSeT51zDWVTXatLWPknWb")
     resolver = Resolver(pool.handle)
     doc = await resolver.resolve("did:indy:sovrin:XvSeT51zDWVTXatLWPknWb")
 
     log(json.dumps(doc, indent=2))
+
+
+    req = build_nym_request(
+        "6qnvgJtqwK44D8LFYnV5Yf", # submitter_did
+        "6qnvgJtqwK44D8LFYnV5Yf", # dest
+        None, # verkey
+        None, # alias
+        None, # role
+        '{"some": "json"}', # diddoc_content
+        0 # self-certification version
+    )
+
+    log("NYM request with diddoc content:", req.body) 
+
+
+    req = build_nym_request(
+        "6qnvgJtqwK44D8LFYnV5Yf", # submitter_did
+        "6qnvgJtqwK44D8LFYnV5Yf", # dest
+        None, # verkey
+        None, # alias
+        None, # role
+        None, # diddoc_content
+        None # self-certification version
+    )
+
+    log("NYM request without diddoc content:", req.body) 
+
+    
+    req = build_get_nym_request(
+        None, # submitter_did
+        "6qnvgJtqwK44D8LFYnV5Yf", # dest
+        None, # seq_no,
+        None, # timestamp
+    )
+
+    log("GET_NYM request without seq_no or timestamp:", req.body) 
+
+    
+    req = build_get_nym_request(
+        None, # submitter_did
+        "6qnvgJtqwK44D8LFYnV5Yf", # dest
+        6, # seq_no,
+        None, # timestamp
+    )
+
+    log("GET_NYM request with seq_np", req.body) 
+
+
+    req = build_get_nym_request(
+        None, # submitter_did
+        "6qnvgJtqwK44D8LFYnV5Yf", # dest
+        None, # seq_no,
+        1647602534, # timestamp
+    )
+
+    log("GET_NYM request with timestamp", req.body) 
 
     # req = build_rich_schema_request(
     #     None, "did:sov:some_hash", '{"some": 1}', "test", "version", "sch", "1.0.0"

--- a/wrappers/python/demo/test.py
+++ b/wrappers/python/demo/test.py
@@ -186,9 +186,10 @@ async def basic_test(transactions_path):
 
 
     # Indy VDR with general indy DID resolution
-    vdr = init_from_github()
-    doc = await vdr.resolve("did:indy:idunion:TUyWgaU7pCG4FQyvrXapf2")
-    log(json.dumps(doc, indent=2))
+    # vdr = init_from_github() # Works only if indy vdr is compiled with feature git
+    # vdr = init_from_folder(path_to_folder)
+    # doc = await vdr.resolve("did:indy:idunion:TUyWgaU7pCG4FQyvrXapf2")
+    # log(json.dumps(doc, indent=2))
 
     # req = build_rich_schema_request(
     #     None, "did:sov:some_hash", '{"some": 1}', "test", "version", "sch", "1.0.0"

--- a/wrappers/python/indy_vdr/bindings.py
+++ b/wrappers/python/indy_vdr/bindings.py
@@ -259,7 +259,7 @@ def pool_create(params: Union[str, bytes, dict]) -> PoolHandle:
 
 def vdr_create_from_github() -> VdrHandle:
     """Create a new vdr instance by retrieving namespaces and genesis files
-    from a Github repo
+    from a Github repo. Only available if indy vdr is compiled with feature git
     """
     handle = VdrHandle()
     

--- a/wrappers/python/indy_vdr/ledger.py
+++ b/wrappers/python/indy_vdr/ledger.py
@@ -489,7 +489,7 @@ def build_nym_request(
     alias: str = None,
     role: str = None,
     diddoc_content: str = None,
-    version: Optional[int] = None,
+    version: int = None
 ) -> Request:
     """
     Builds a NYM request to create new DID on the ledger.
@@ -521,7 +521,7 @@ def build_nym_request(
     alias_p = encode_str(alias) if alias else None
     role_p = encode_str(role) if role else None
     diddoc_content_p = encode_str(diddoc_content) if diddoc_content else None
-    version = c_int32(version if version is not None else -1)
+    version_p = c_int32(version if version is not None else -1)
     do_call(
         "indy_vdr_build_nym_request",
         did_p,
@@ -530,7 +530,7 @@ def build_nym_request(
         alias_p,
         role_p,
         diddoc_content_p,
-        version,
+        version_p,
         byref(handle),
     )
     return Request(handle)

--- a/wrappers/python/indy_vdr/resolver.py
+++ b/wrappers/python/indy_vdr/resolver.py
@@ -10,10 +10,10 @@ class Resolver:
 
     async def resolve(self, did: str) -> dict:
         """Resolve a DID to retrieve a DID Doc."""
-        result = await bindings.resolve(self.handle, did)
+        result = await bindings.pool_resolve(self.handle, did)
         return result
 
     async def dereference(self, did_url: str) -> dict:
         """Dereference a DID Url to retrieve a ledger object."""
-        result = await bindings.dereference(self.handle, did_url)
+        result = await bindings.pool_dereference(self.handle, did_url)
         return result

--- a/wrappers/python/indy_vdr/vdr.py
+++ b/wrappers/python/indy_vdr/vdr.py
@@ -21,7 +21,10 @@ class Vdr:
 
 
 def init_from_github() -> Vdr:
-    """Initialize indy vdr with standard networks."""
+    """Initialize indy vdr with standard networks.
+    This is only available if indy vdr is compiled with
+    feature git.
+    """
     vdr = Vdr(bindings.vdr_create_from_github())
     return vdr
 

--- a/wrappers/python/indy_vdr/vdr.py
+++ b/wrappers/python/indy_vdr/vdr.py
@@ -1,0 +1,32 @@
+from . import bindings
+from .error import VdrError, VdrErrorCode
+
+class Vdr:
+    """An opened vdr instance."""
+
+    def __init__(self, handle: bindings.VdrHandle):
+        """Initialize the vdr instance."""
+        self.handle = handle
+    
+    async def resolve(self, did: str) -> dict:
+        """Resolve a DID to retrieve a DID Doc."""
+        result = await bindings.vdr_resolve(self.handle, did)
+        return result
+
+    # FIXME: Not yet implemented
+    # async def refresh_all(self) -> dict:
+    #     """Refresh all validator pools."""
+    #     result = await bindings.vdr_refresh(self.handle)
+    #     return result
+
+
+def init_from_github() -> Vdr:
+    """Initialize indy vdr with standard networks."""
+    vdr = Vdr(bindings.vdr_create_from_github())
+    return vdr
+
+def init_from_folder(path: str, genesis_filename = None) -> Vdr:
+    """Initialize indy vdr from local folder."""
+    vdr = Vdr(bindings.vdr_create_from_folder(path, genesis_filename))
+    return vdr
+

--- a/wrappers/python/indy_vdr/vdr.py
+++ b/wrappers/python/indy_vdr/vdr.py
@@ -1,5 +1,6 @@
 from . import bindings
-from .error import VdrError, VdrErrorCode
+
+from typing import List
 
 class Vdr:
     """An opened vdr instance."""
@@ -7,17 +8,20 @@ class Vdr:
     def __init__(self, handle: bindings.VdrHandle):
         """Initialize the vdr instance."""
         self.handle = handle
+
+    def get_ledgers(self) -> List[str]:
+        result = bindings.vdr_get_ledgers(self.handle)
+        return result
     
     async def resolve(self, did: str) -> dict:
         """Resolve a DID to retrieve a DID Doc."""
         result = await bindings.vdr_resolve(self.handle, did)
         return result
 
-    # FIXME: Not yet implemented
-    # async def refresh_all(self) -> dict:
-    #     """Refresh all validator pools."""
-    #     result = await bindings.vdr_refresh(self.handle)
-    #     return result
+
+    async def refresh(self, ledger: str):
+        """Refresh a validator pool."""
+        await bindings.vdr_refresh(self.handle, ledger)
 
 
 def init_from_github() -> Vdr:


### PR DESCRIPTION
Builds upon #80 

- Adds a VDR API with a general DID resolver. Network configuration can be taken from a Github Repo or a local folder structure
- Initial support for multiple ledgers and DID resolution with indy-vdr-proxy

The VDR API uses Async/Await and is therefore not suited for FFI, but I'll look into it.

I think it would help to create a `did-indy` branch to have smaller PRs at some point :) 