### PR TITLE
Feature/proxy with multiple ledger support

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,3 @@
 .git
 target
+github

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,7 +2,7 @@ name: "Indy-VDR"
 
 on:
   push:
-    branches: [main, did-indy, integration_test]
+    branches: [main, did-indy]
   pull_request:
     branches: [main, did-indy]
   release:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,9 +2,9 @@ name: "Indy-VDR"
 
 on:
   push:
-    branches: [main]
+    branches: [main, did-indy, integration_test]
   pull_request:
-    branches: [main]
+    branches: [main, did-indy]
   release:
     types: [created]
   workflow_dispatch:
@@ -71,7 +71,7 @@ jobs:
 
       - name: Run node pool
         run: |
-          docker build -f ci/indy-pool.dockerfile -t test_pool --build-arg pool_ip=10.0.0.2 ci
+          docker build -f ci/did-indy-pool.dockerfile -t test_pool --build-arg pool_ip=10.0.0.2 ci
           docker network create --subnet=10.0.0.0/8 indy-sdk-network
           docker run -d --name indy_pool -p 9701-9708:9701-9708 --net=indy-sdk-network test_pool
 
@@ -79,7 +79,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --manifest-path libindy_vdr/Cargo.toml --features local_nodes_pool
+          args: --manifest-path libindy_vdr/Cargo.toml --features local_nodes_pool,local_nodes_pool_did_indy
 
   build-manylinux:
     name: Build Library (Manylinux)

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ node_modules
 Podfile.lock
 .vscode
 coverage
+github

--- a/README.md
+++ b/README.md
@@ -39,27 +39,45 @@ At a later stage it should be possible to install a precompiled 'wheel' package 
 
 ## Proxy Server
 
-The `indy-vdr-proxy` executable can be used to provide a simple REST API for interacting with the ledger. Command line options can be inspected by running `indy-vdr-proxy --help`.
+The `indy-vdr-proxy` executable can be used to provide a simple REST API for interacting with one or more Indy ledgers. Command line options can be inspected by running `indy-vdr-proxy --help`.
+
+To start the proxy server for a single ledger use the following command:
+`indy-vdr-proxy -p <PORT> (-g <OPTIONAL_PATH_TO_GENESIS_FILE>)`
+
+To start the proxy server with the standard configuration of indy ledgers use the following command:
+`indy-vdr-proxy -p <PORT> --multiple-ledgers`
+This will get the ledger configuration from `https://github.com/IDunion/indy-did-networks`
+
+A custom ledger configuration can be provided either by specificing a Github repo or a local folder:
+`indy-vdr-proxy -p <PORT> --multiple-ledgers -g <GITHUB_URL or PATH_TO_FOLDER>`
+The structure needs to be as follows `<NAMESPACE>/OPTIONAL<SUB_NAMESPACE>/pool_transactions_genesis.json`, e.g. `/sovrin/staging/pool_transactions_genesis.json`
 
 Responses can be formatted in either HTML or JSON formats. HTML formatting is selected when the `text/html` content type is requested according to the Accept header (as sent by web browsers) or the request query string is set to `?html`. JSON formatting is selected otherwise, and may be explitly selected by using the query string `?raw`. For most ledger requests, JSON responses include information regarding which nodes were contacted is returned in the `X-Requests` header.
 
-Sending prepared requests to the ledger is performed by delivering a POST request to the `/submit` endpoint, where the body of the request is the JSON-formatted payload. Additional endpoints are provided as shortcuts for ledger read transactions:
+Sending prepared requests to the ledger is performed by delivering a POST request to the `{LEDGER}/submit` endpoint, where the body of the request is the JSON-formatted payload. Additional endpoints are provided as shortcuts for ledger read transactions:
 
-- `/` The root path shows basic status information about the server and the ledger pool
-- `/genesis` Return the current set of genesis transactions
-- `/taa` Fetch the current ledger Transaction Author Agreement
-- `/aml` Fetch the current ledger Acceptance Methods List (for the TAA)
-- `/nym/{DID}` Fetch the NYM transaction associated with a DID
-- `/attrib/{DID}/endpoint` Fetch the registered endpoint for a DID
-- `/schema/{SCHEMA_ID}` Fetch a schema by its identifier
-- `/cred_def/{CRED_DEF_ID}` Fetch a credential definition by its identifier
-- `/rev_reg/{REV_REG_ID}` Fetch a revocation registry by its identifier
-- `/rev_reg_def/{REV_REG_ID}` Fetch a revocation registry definition by its registry identifier
-- `/rev_reg_delta/{REV_REG_ID}` Fetch a revocation registry delta by its registry identifier
-- `/auth` Fetch all AUTH rules for the ledger
-- `/auth/{TXN_TYPE}/{ADD|EDIT}` Fetch the AUTH rule for a specific transaction type and action
-- `/txn/{SUBLEDGER}/{SEQ_NO}` Fetch a specific transaction by subledger identifier (0-2, or one of `pool`, `domain`, or `config`) and sequence number.
+- `{LEDGER}/` The root path shows basic status information about the server and the ledger pool
+- `{LEDGER}/genesis` Return the current set of genesis transactions
+- `{LEDGER}/taa` Fetch the current ledger Transaction Author Agreement
+- `{LEDGER}/aml` Fetch the current ledger Acceptance Methods List (for the TAA)
+- `{LEDGER}/nym/{DID}` Fetch the NYM transaction associated with an unqualified DID
+- `{LEDGER}/attrib/{DID}/endpoint` Fetch the registered endpoint for an unqualified DID
+- `{LEDGER}/schema/{SCHEMA_ID}` Fetch a schema by its identifier
+- `{LEDGER}/cred_def/{CRED_DEF_ID}` Fetch a credential definition by its identifier
+- `{LEDGER}/rev_reg/{REV_REG_ID}` Fetch a revocation registry by its identifier
+- `{LEDGER}/rev_reg_def/{REV_REG_ID}` Fetch a revocation registry definition by its registry identifier
+- `{LEDGER}/rev_reg_delta/{REV_REG_ID}` Fetch a revocation registry delta by its registry identifier
+- `{LEDGER}/auth` Fetch all AUTH rules for the ledger
+- `{LEDGER}/auth/{TXN_TYPE}/{ADD|EDIT}` Fetch the AUTH rule for a specific transaction type and action
+- `{LEDGER}/txn/{SUBLEDGER}/{SEQ_NO}` Fetch a specific transaction by subledger identifier (0-2, or one of `pool`, `domain`, or `config`) and sequence number.
 
+If the proxy server is used with a single ledger, the `{LEDGER}` part of the path must be omitted.
+
+### DID:Indy Resolver
+
+Indy VDR contains a DID Resolver to resolve DIDs and dereference DID Urls to ledger objects from configured ledgers according to the [did:indy specification](https://hyperledger.github.io/indy-did-method/).
+
+`GET /1.0/identifiers/{DID or DID_URL}`
 ## Connecting to a Ledger
 
 Whether using the library or the proxy server, you will need a `genesis.txn` file containing the set of pool genesis transactions. You can run a local pool in Docker using [VON-Network](https://github.com/bcgov/von-network) or follow the [Indy-SDK instructions](https://github.com/hyperledger/indy-sdk#how-to-start-local-nodes-pool-with-docker).

--- a/README.md
+++ b/README.md
@@ -55,8 +55,8 @@ The structure needs to be as follows `<NAMESPACE>/OPTIONAL<SUB_NAMESPACE>/pool_t
 Responses can be formatted in either HTML or JSON formats. HTML formatting is selected when the `text/html` content type is requested according to the Accept header (as sent by web browsers) or the request query string is set to `?html`. JSON formatting is selected otherwise, and may be explitly selected by using the query string `?raw`. For most ledger requests, JSON responses include information regarding which nodes were contacted is returned in the `X-Requests` header.
 
 Sending prepared requests to the ledger is performed by delivering a POST request to the `{LEDGER}/submit` endpoint, where the body of the request is the JSON-formatted payload. Additional endpoints are provided as shortcuts for ledger read transactions:
-
-- `{LEDGER}/` The root path shows basic status information about the server and the ledger pool
+- `/` Return configured ledgers 
+- `{LEDGER}/` Basic status information about the server and the ledger pool
 - `{LEDGER}/genesis` Return the current set of genesis transactions
 - `{LEDGER}/taa` Fetch the current ledger Transaction Author Agreement
 - `{LEDGER}/aml` Fetch the current ledger Acceptance Methods List (for the TAA)

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Sending prepared requests to the ledger is performed by delivering a POST reques
 - `{LEDGER}/genesis` Return the current set of genesis transactions
 - `{LEDGER}/taa` Fetch the current ledger Transaction Author Agreement
 - `{LEDGER}/aml` Fetch the current ledger Acceptance Methods List (for the TAA)
-- `{LEDGER}/nym/{DID}` Fetch the NYM transaction associated with an unqualified DID
+- `{LEDGER}/nym/{DID}` Fetch the NYM transaction associated with an unqualified DID. Can be used with `timestamp` or `seq_no` query parameters to fetch specific versions
 - `{LEDGER}/attrib/{DID}/endpoint` Fetch the registered endpoint for an unqualified DID
 - `{LEDGER}/schema/{SCHEMA_ID}` Fetch a schema by its identifier
 - `{LEDGER}/cred_def/{CRED_DEF_ID}` Fetch a credential definition by its identifier

--- a/ci/did-indy-pool.dockerfile
+++ b/ci/did-indy-pool.dockerfile
@@ -1,0 +1,152 @@
+FROM --platform=linux/amd64 ubuntu:20.04
+
+ARG uid=1000
+# ARG user=indy
+
+RUN apt-get update -y && apt-get install -y \
+    # common stuff
+    git \
+    wget \
+    gnupg \
+    apt-transport-https \
+    ca-certificates \
+    apt-utils
+
+# ========================================================================================================
+# Update repository signing keys
+# --------------------------------------------------------------------------------------------------------
+# Hyperledger
+RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 9692C00E657DDE61 && \
+    # Sovrin
+    apt-key adv --keyserver keyserver.ubuntu.com --recv-keys CE7709D068DB5E88
+# ========================================================================================================
+
+# Plenum
+#  - https://github.com/hyperledger/indy-plenum/issues/1546
+#  - Needed to pick up rocksdb=5.8.8
+RUN echo "deb  https://hyperledger.jfrog.io/artifactory/indy focal dev"  >> /etc/apt/sources.list && \
+    echo "deb http://security.ubuntu.com/ubuntu bionic-security main"  >> /etc/apt/sources.list && \
+    echo "deb https://repo.sovrin.org/deb bionic master" >> /etc/apt/sources.list && \
+    echo "deb https://repo.sovrin.org/sdk/deb bionic master" >> /etc/apt/sources.list
+
+# Sovrin
+RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys CE7709D068DB5E88 
+
+RUN apt-get update -y && apt-get install -y \
+    # Python
+    python3-pip \
+    python3-nacl \
+    # rocksdb python wrapper
+    rocksdb=5.8.8 \
+    libgflags-dev \
+    libsnappy-dev \
+    zlib1g-dev \
+    libbz2-dev \
+    liblz4-dev \
+    libgflags-dev \
+    # zstd is needed for caching in github actions pipeline
+    zstd \
+    # fpm
+    ruby \
+    ruby-dev \
+    rubygems \
+    gcc \
+    make \
+    # Indy Node and Plenum
+    libssl1.0.0 \
+    ursa=0.3.2-1 \
+    # Indy SDK
+    libindy=1.15.0~1625-bionic \
+    # Need to move libursa.so to parent dir
+    && mv /usr/lib/ursa/* /usr/lib && rm -rf /usr/lib/ursa
+
+RUN pip3 install -U \
+    # Required by setup.py
+    setuptools==50.3.2 \
+    # Still pinned. Needs to be update like in plenum
+    'pip<10.0.0' \
+    'pyzmq==18.1.0' \
+	'supervisor~=4.2'
+
+
+# install fpm
+RUN gem install --no-document rake fpm
+
+RUN apt-get -y autoremove \
+    && rm -rf /var/lib/apt/lists/*
+
+# Download, build and install indy-node
+RUN git clone --single-branch --branch feature/did-indy-new https://github.com/indicio-tech/indy-node && \
+    pip install -e indy-node
+
+
+RUN echo "[supervisord]\n\
+logfile = /tmp/supervisord.log\n\
+logfile_maxbytes = 50MB\n\
+logfile_backups=10\n\
+logLevel = error\n\
+pidfile = /tmp/supervisord.pid\n\
+nodaemon = true\n\
+minfds = 1024\n\
+minprocs = 200\n\
+umask = 022\n\
+user = indy\n\
+identifier = supervisor\n\
+directory = /tmp\n\
+nocleanup = true\n\
+childlogdir = /tmp\n\
+strip_ansi = false\n\
+\n\
+[program:node1]\n\
+command=start_indy_node Node1 0.0.0.0 9701 0.0.0.0 9702\n\
+directory=/home/indy\n\
+stdout_logfile=/tmp/node1.log\n\
+stderr_logfile=/tmp/node1.log\n\
+\n\
+[program:node2]\n\
+command=start_indy_node Node2 0.0.0.0 9703 0.0.0.0 9704\n\
+directory=/home/indy\n\
+stdout_logfile=/tmp/node2.log\n\
+stderr_logfile=/tmp/node2.log\n\
+\n\
+[program:node3]\n\
+command=start_indy_node Node3 0.0.0.0 9705 0.0.0.0 9706\n\
+directory=/home/indy\n\
+stdout_logfile=/tmp/node3.log\n\
+stderr_logfile=/tmp/node3.log\n\
+\n\
+[program:node4]\n\
+command=start_indy_node Node4 0.0.0.0 9707 0.0.0.0 9708\n\
+directory=/home/indy\n\
+stdout_logfile=/tmp/node4.log\n\
+stderr_logfile=/tmp/node4.log\n"\
+>> /etc/supervisord.conf
+
+RUN useradd -ms /bin/bash -u $uid indy
+
+RUN mkdir -p \
+	/etc/indy \
+	/var/lib/indy/backup \
+	/var/lib/indy/plugins \
+	/var/log/indy \
+	&& chown -R indy /etc/indy /var/lib/indy /var/log/indy
+
+USER indy
+
+RUN echo "LEDGER_DIR = '/var/lib/indy'\n\
+LOG_DIR = '/var/log/indy'\n\
+KEYS_DIR = '/var/lib/indy'\n\
+GENESIS_DIR = '/var/lib/indy'\n\
+BACKUP_DIR = '/var/lib/indy/backup'\n\
+PLUGINS_DIR = '/var/lib/indy/plugins'\n\
+NODE_INFO_DIR = '/var/lib/indy'\n\
+NETWORK_NAME = 'sandbox'\n"\
+>> /etc/indy/indy_config.py
+
+ARG pool_ip=127.0.0.1
+
+RUN generate_indy_pool_transactions --nodes 4 --clients 5 --nodeNum 1 2 3 4 --ips="$pool_ip,$pool_ip,$pool_ip,$pool_ip"
+
+EXPOSE 9701 9702 9703 9704 9705 9706 9707 9708
+
+CMD ["/usr/local/bin/supervisord"]

--- a/indy-vdr-proxy/Cargo.toml
+++ b/indy-vdr-proxy/Cargo.toml
@@ -14,12 +14,15 @@ default = ["fetch", "zmq_vendored"]
 [dependencies]
 clap = "3.1"
 env_logger = "0.9"
+futures-executor = "0.3"
 futures-util = "0.3"
 indy-vdr = { version = "0.4", path = "../libindy_vdr", default-features = false, features = ["log"] }
+git2 = "0.14.2"
 hyper = { version = "0.14", features = ["http1", "http2", "server"] }
 hyper-tls = { version = "0.5", optional = true }
 log = "0.4.8"
 percent-encoding = "2"
+regex = "1.5.4"
 serde_json = "1.0"
 tokio = { version = "1.0", features = ["macros", "rt-multi-thread", "signal"] }
 url = "2.2.2"

--- a/indy-vdr-proxy/src/handlers.rs
+++ b/indy-vdr-proxy/src/handlers.rs
@@ -265,7 +265,10 @@ fn get_pool_status(state: Rc<RefCell<AppState>>, namespace: &str) -> VdrResult<R
     let pool_states = &state.borrow().pool_states;
     let opt_pool = &pool_states
         .get(namespace)
-        .ok_or(err_msg(VdrErrorKind::Input, format!("Unkown ledger: {}", namespace)))?
+        .ok_or(err_msg(
+            VdrErrorKind::Input,
+            format!("Unkown ledger: {}", namespace),
+        ))?
         .pool;
     let (status, mt_root, mt_size, nodes) = if let Some(pool) = opt_pool {
         let (mt_root, mt_size) = pool.get_merkle_tree_info();

--- a/indy-vdr-proxy/src/main.rs
+++ b/indy-vdr-proxy/src/main.rs
@@ -3,16 +3,20 @@ extern crate serde_json;
 
 mod app;
 mod handlers;
+mod utils;
 
 use std::cell::RefCell;
+use std::collections::HashMap;
 #[cfg(unix)]
 use std::fs;
 use std::net::IpAddr;
+use std::path::PathBuf;
 use std::process::exit;
 use std::rc::Rc;
-use std::time::{Duration, SystemTime};
+use std::time::Duration;
 
-use futures_util::FutureExt;
+use futures_util::future::FutureExt;
+use git2::Repository;
 
 #[cfg(feature = "fetch")]
 use hyper::body::Buf;
@@ -33,6 +37,10 @@ use tokio::signal::unix::SignalKind;
 use indy_vdr::common::error::prelude::*;
 use indy_vdr::pool::{helpers::perform_refresh, LocalPool, PoolBuilder, PoolTransactions};
 
+use crate::utils::{
+    init_pool_state_from_folder_structure, AppState, PoolState, INDY_NETWORKS_GITHUB,
+};
+
 fn main() {
     let config = app::load_config().unwrap_or_else(|err| {
         eprintln!("{}", err);
@@ -51,12 +59,6 @@ fn main() {
         eprintln!("{}", err);
         exit(1);
     }
-}
-
-pub struct AppState {
-    pool: Option<LocalPool>,
-    last_refresh: Option<SystemTime>,
-    transactions: PoolTransactions,
 }
 
 #[cfg(feature = "fetch")]
@@ -95,50 +97,124 @@ async fn fetch_transactions(_genesis: String) -> VdrResult<PoolTransactions> {
     ))
 }
 
-async fn init_app_state(genesis: String) -> VdrResult<AppState> {
-    let transactions = if genesis.starts_with("http:") || genesis.starts_with("https:") {
-        fetch_transactions(genesis).await?
+async fn init_app_state(
+    genesis: Option<String>,
+    namespace: String,
+    is_multiple: bool,
+) -> VdrResult<AppState> {
+    let mut pool_states: HashMap<String, PoolState> = HashMap::new();
+
+    let state = if !is_multiple {
+        let genesis = genesis.unwrap_or(String::from("genesis.txn"));
+        let transactions = if genesis.starts_with("http:") || genesis.starts_with("https:") {
+            fetch_transactions(genesis).await?
+        } else {
+            PoolTransactions::from_json_file(genesis.as_str())?
+        };
+        let pool_state = PoolState {
+            pool: None,
+            last_refresh: None,
+            transactions,
+        };
+        pool_states.insert(namespace, pool_state);
+        AppState {
+            is_multiple,
+            pool_states,
+        }
     } else {
-        PoolTransactions::from_json_file(genesis.as_str())?
-    };
-    let state = AppState {
-        pool: None,
-        last_refresh: None,
-        transactions,
+        let genesis = genesis.unwrap_or(String::from(INDY_NETWORKS_GITHUB));
+        let pool_states = if genesis.starts_with("https:") {
+            let repo_url = genesis;
+            let mut just_cloned = false;
+            let repo =
+                git2::Repository::discover("github").or_else(|_| -> VdrResult<Repository> {
+                    just_cloned = true;
+                    Repository::clone(&repo_url, "github").map_err(|_err| {
+                        err_msg(VdrErrorKind::Unexpected, "Could not clone networks repo")
+                    })
+                })?;
+
+            // Fetch remote if not cloned just now
+            if !just_cloned {
+                let mut origin_remote = repo.find_remote("origin").map_err(|_err| {
+                    err_msg(
+                        VdrErrorKind::Unexpected,
+                        "Networks repo has no remote origin",
+                    )
+                })?;
+
+                origin_remote.fetch(&["main"], None, None).map_err(|_err| {
+                    err_msg(
+                        VdrErrorKind::Unexpected,
+                        "Could not fetch from remote networks repo",
+                    )
+                })?;
+            }
+
+            let path = repo.path().parent().unwrap().to_owned();
+
+            init_pool_state_from_folder_structure(PathBuf::from(path))?
+        } else {
+            init_pool_state_from_folder_structure(PathBuf::from(genesis))?
+        };
+        AppState {
+            is_multiple,
+            pool_states,
+        }
     };
     Ok(state)
 }
 
-async fn run_pool(state: Rc<RefCell<AppState>>, init_refresh: bool, interval_refresh: u32) {
-    let mut pool = match create_pool(state.clone(), init_refresh).await {
-        Ok(pool) => {
-            state.borrow_mut().pool.replace(pool.clone());
-            pool
-        }
-        Err(err) => {
-            eprintln!("Error initializing pool: {}", err);
-            return;
-        }
-    };
+async fn run_pools(state: Rc<RefCell<AppState>>, init_refresh: bool, interval_refresh: u32) {
+    let mut pool_states = HashMap::new();
+
+    for (namespace, pool_state) in &state.clone().borrow().pool_states {
+        let pool_state = match create_pool(state.clone(), namespace.as_str(), init_refresh).await {
+            Ok(pool) => {
+                let pool = Some(pool.clone());
+                PoolState {
+                    pool: pool.clone(),
+                    last_refresh: pool_state.last_refresh.clone(),
+                    transactions: pool_state.transactions.clone()
+                }
+            }
+            Err(err) => {
+                eprintln!("Error initializing pool: {}", err);
+                PoolState {
+                    pool: None,
+                    last_refresh: pool_state.last_refresh.clone(),
+                    transactions: pool_state.transactions.clone()
+                }
+            }
+        };
+
+        pool_states.insert(namespace.to_owned(), pool_state);
+
+    }
+
+    state.borrow_mut().pool_states = pool_states;
+
+
+
     let shutdown = shutdown_signal().fuse().shared();
     if interval_refresh > 0 {
         loop {
             select! {
-                refresh_result = refresh_pool(state.clone(), &pool, interval_refresh) => {
-                    match refresh_result {
-                        Ok(Some(upd_pool)) => {
-                            state.borrow_mut().pool.replace(upd_pool.clone());
-                            pool = upd_pool;
-                            log::info!("Refreshed validator pool");
-                        }
-                        Ok(None) => {
-                            log::debug!("Refreshed validator pool, no change");
-                        }
-                        Err(err) => {
-                            log::error!("Error refreshing validator pool: {}", err);
-                        }
-                    }
-                }
+                // refresh_result = refresh_pool(state.clone(), namespace, &pool, interval_refresh) => {
+                //     match refresh_result {
+                //         Ok(Some(upd_pool)) => {
+                //             state.borrow_mut().pool.replace(upd_pool.clone());
+                //             pool = upd_pool;
+                //             log::info!("Refreshed validator pool");
+                //         }
+                //         Ok(None) => {
+                //             log::debug!("Refreshed validator pool, no change");
+                //         }
+                //         Err(err) => {
+                //             log::error!("Error refreshing validator pool: {}", err);
+                //         }
+                //     }
+                // }
                 _ = shutdown.clone() => {
                     println!("Shutting down");
                     break;
@@ -171,11 +247,17 @@ async fn shutdown_signal() {
         .expect("failed to install Ctrl-C handler")
 }
 
-async fn create_pool(state: Rc<RefCell<AppState>>, refresh: bool) -> VdrResult<LocalPool> {
-    let builder = PoolBuilder::default().transactions(state.borrow().transactions.clone())?;
+async fn create_pool(
+    state: Rc<RefCell<AppState>>,
+    namespace: &str,
+    refresh: bool,
+) -> VdrResult<LocalPool> {
+    let pool_states = &state.borrow().pool_states;
+    let pool_state = pool_states.get(namespace).unwrap();
+    let builder = PoolBuilder::default().transactions(pool_state.transactions.clone())?;
     let pool = builder.into_local()?;
     let refresh_pool = if refresh {
-        refresh_pool(state, &pool, 0).await?
+        refresh_pool(state.clone(), namespace, &pool, 0).await?
     } else {
         None
     };
@@ -184,6 +266,7 @@ async fn create_pool(state: Rc<RefCell<AppState>>, refresh: bool) -> VdrResult<L
 
 async fn refresh_pool(
     state: Rc<RefCell<AppState>>,
+    namespace: &str,
     pool: &LocalPool,
     delay_mins: u32,
 ) -> VdrResult<Option<LocalPool>> {
@@ -193,11 +276,14 @@ async fn refresh_pool(
 
     let (txns, _timing) = perform_refresh(pool).await?;
 
-    state.borrow_mut().last_refresh.replace(SystemTime::now());
+    let cloned_state = state.clone();
+    let pool_states = &cloned_state.borrow().pool_states;
+    let pool_state = pool_states.get(namespace).unwrap();
+
+    let pool_txns = &mut pool_state.transactions.to_owned();
 
     if let Some(txns) = txns {
         let builder = {
-            let pool_txns = &mut state.borrow_mut().transactions;
             pool_txns.extend_from_json(&txns)?;
             PoolBuilder::default().transactions(pool_txns.clone())?
         };
@@ -209,9 +295,13 @@ async fn refresh_pool(
 
 async fn init_server(config: app::Config) -> Result<(), String> {
     let state = Rc::new(RefCell::new(
-        init_app_state(config.genesis.clone())
-            .await
-            .map_err(|err| format!("Error loading config: {}", err))?,
+        init_app_state(
+            config.genesis.clone(),
+            config.namespace.clone(),
+            config.is_multiple,
+        )
+        .await
+        .map_err(|err| format!("Error loading config: {}", err))?,
     ));
 
     #[cfg(unix)]
@@ -253,7 +343,7 @@ where
     I::Conn: tokio::io::AsyncRead + tokio::io::AsyncWrite + Send + Unpin,
     I::Error: Into<Box<dyn std::error::Error + Send + Sync>>,
 {
-    let until_done = run_pool(state.clone(), config.init_refresh, config.interval_refresh);
+    let until_done = run_pools(state.clone(), config.init_refresh, config.interval_refresh);
     let svc = make_service_fn(move |_| {
         let state = state.clone();
         async move {

--- a/indy-vdr-proxy/src/main.rs
+++ b/indy-vdr-proxy/src/main.rs
@@ -13,7 +13,7 @@ use std::net::IpAddr;
 use std::path::PathBuf;
 use std::process::exit;
 use std::rc::Rc;
-use std::time::Duration;
+use std::time::{Duration, SystemTime};
 
 use futures_util::future::FutureExt;
 use git2::Repository;
@@ -179,7 +179,7 @@ async fn run_pools(state: Rc<RefCell<AppState>>, init_refresh: bool, interval_re
                 }
             }
             Err(err) => {
-                eprintln!("Error initializing pool: {}", err);
+                eprintln!("Error initializing pool {} with error : {}", namespace, err);
                 PoolState {
                     pool: None,
                     last_refresh: pool_state.last_refresh.clone(),
@@ -197,21 +197,17 @@ async fn run_pools(state: Rc<RefCell<AppState>>, init_refresh: bool, interval_re
     if interval_refresh > 0 {
         loop {
             select! {
-                // refresh_result = refresh_pool(state.clone(), namespace, &pool, interval_refresh) => {
-                //     match refresh_result {
-                //         Ok(Some(upd_pool)) => {
-                //             state.borrow_mut().pool.replace(upd_pool.clone());
-                //             pool = upd_pool;
-                //             log::info!("Refreshed validator pool");
-                //         }
-                //         Ok(None) => {
-                //             log::debug!("Refreshed validator pool, no change");
-                //         }
-                //         Err(err) => {
-                //             log::error!("Error refreshing validator pool: {}", err);
-                //         }
-                //     }
-                // }
+                refresh_result = refresh_pools(state.clone(), interval_refresh) => {
+                    match refresh_result {
+                        Ok(upd_pool_states) => {
+                            state.borrow_mut().pool_states = upd_pool_states;
+                            log::info!("Refreshed validator pools");
+                        },
+                        Err(err) => {
+                            log::error!("Error refreshing validator pool: {}", err);
+                        }
+                    }
+                }
                 _ = shutdown.clone() => {
                     println!("Shutting down");
                     break;
@@ -261,14 +257,47 @@ async fn create_pool(
     Ok(refresh_pool.unwrap_or(pool))
 }
 
+async fn refresh_pools(
+    state: Rc<RefCell<AppState>>,
+    // pool_states: HashMap<String, PoolState>,
+    delay_mins: u32,
+) -> VdrResult<HashMap<String, PoolState>> {
+    let mut upd_pool_states = HashMap::new();
+    let pool_states = &state.borrow().pool_states;
+    for (namespace, pool_state) in pool_states {
+        if let Some(pool) = &pool_state.pool {
+            let upd_pool = match refresh_pool(state.clone(), &namespace, &pool, delay_mins).await {
+                Ok(p) => p,
+                Err(err) => {
+                    eprintln!(
+                        "Error refreshing validator pool {} with error {}",
+                        namespace, err
+                    );
+                    None
+                }
+            };
+            let upd_pool_state = PoolState {
+                pool: upd_pool.or(Some(pool.clone())),
+                last_refresh: Some(SystemTime::now()),
+                transactions: pool_state.transactions.clone(),
+            };
+
+            upd_pool_states.insert(namespace.to_owned(), upd_pool_state);
+        }
+    }
+
+    Ok(upd_pool_states)
+}
+
 async fn refresh_pool(
     state: Rc<RefCell<AppState>>,
     namespace: &str,
     pool: &LocalPool,
     delay_mins: u32,
 ) -> VdrResult<Option<LocalPool>> {
+    let n_pools = state.borrow().pool_states.len() as u32;
     if delay_mins > 0 {
-        tokio::time::sleep(Duration::from_secs((delay_mins * 60) as u64)).await
+        tokio::time::sleep(Duration::from_secs((delay_mins * 60 / n_pools) as u64)).await
     }
 
     let (txns, _timing) = perform_refresh(pool).await?;

--- a/indy-vdr-proxy/src/utils.rs
+++ b/indy-vdr-proxy/src/utils.rs
@@ -1,0 +1,74 @@
+use std::collections::HashMap;
+use std::fs;
+use std::path::PathBuf;
+use std::time::SystemTime;
+
+use indy_vdr::common::error::prelude::*;
+use indy_vdr::pool::{LocalPool, PoolTransactions};
+
+pub const INDY_NETWORKS_GITHUB: &str = "https://github.com/IDunion/indy-did-networks";
+pub const GENESIS_FILENAME: &str = "pool_transactions_genesis.json";
+
+pub struct PoolState {
+    pub pool: Option<LocalPool>,
+    pub last_refresh: Option<SystemTime>,
+    pub transactions: PoolTransactions,
+}
+
+pub struct AppState {
+    pub is_multiple: bool,
+    pub pool_states: HashMap<String, PoolState>,
+}
+
+pub fn init_pool_state_from_folder_structure(
+    path: PathBuf,
+) -> VdrResult<HashMap<String, PoolState>> {
+    let mut networks = HashMap::new();
+
+    let entries = fs::read_dir(path).map_err(|err| {
+        err_msg(
+            VdrErrorKind::FileSystem(err),
+            "Could not read local networks folder",
+        )
+    })?;
+
+    for entry in entries {
+        let entry = entry.unwrap();
+        // filter hidden directories starting with "." and files
+        if !entry.file_name().to_str().unwrap().starts_with(".")
+            && entry.metadata().unwrap().is_dir()
+        {
+            let namespace = entry.path().file_name().unwrap().to_owned();
+            let sub_entries = fs::read_dir(entry.path()).unwrap();
+            for sub_entry in sub_entries {
+                let sub_entry_path = sub_entry.unwrap().path();
+                let sub_namespace = if sub_entry_path.is_dir() {
+                    sub_entry_path.file_name()
+                } else {
+                    None
+                };
+                let (ledger_prefix, genesis_txns) = match sub_namespace {
+                    Some(sub_namespace) => (
+                        format!(
+                            "{}:{}",
+                            namespace.to_str().unwrap(),
+                            sub_namespace.to_str().unwrap()
+                        ),
+                        PoolTransactions::from_json_file(sub_entry_path.join(GENESIS_FILENAME))?,
+                    ),
+                    None => (
+                        String::from(namespace.to_str().unwrap()),
+                        PoolTransactions::from_json_file(entry.path().join(GENESIS_FILENAME))?,
+                    ),
+                };
+                let pool_state = PoolState {
+                    pool: None,
+                    last_refresh: None,
+                    transactions: genesis_txns,
+                };
+                networks.insert(ledger_prefix, pool_state);
+            }
+        }
+    }
+    Ok(networks)
+}

--- a/libindy_vdr/Cargo.toml
+++ b/libindy_vdr/Cargo.toml
@@ -20,6 +20,7 @@ ffi = ["ffi-support", "logger"]
 logger = ["env_logger", "log"]
 zmq_vendored = ["zmq/vendored"]
 local_nodes_pool = []
+local_nodes_pool_did_indy = []
 rich_schema = ["indy-data-types/rich_schema"]
 default = ["ffi", "log", "zmq_vendored"]
 

--- a/libindy_vdr/src/ffi/ledger.rs
+++ b/libindy_vdr/src/ffi/ledger.rs
@@ -413,9 +413,15 @@ pub extern "C" fn indy_vdr_build_nym_request(
         let verkey = verkey.into_opt_string();
         let alias = alias.into_opt_string();
         let role = role.into_opt_string();
-        let diddoc_content = serde_json::from_str(diddoc_content.as_str()).with_input_err("Error deserializing diddoc_content as JSON")?;
+        let diddoc_content = match diddoc_content.as_opt_str() {
+            Some(s) => {
+                let js = serde_json::from_str(s).with_input_err("Error deserializing raw value as JSON")?;
+                Some(js)
+            }
+            None => None,
+        };
         let version = if version == -1 { None } else { Some(version) };
-        let req = builder.build_nym_request(&identifier, &dest, verkey, alias, role, diddoc_content, version)?;
+        let req = builder.build_nym_request(&identifier, &dest, verkey, alias, role, diddoc_content.as_ref(), version)?;
         let handle = add_request(req)?;
         unsafe {
             *handle_p = handle;

--- a/libindy_vdr/src/ledger/request_builder.rs
+++ b/libindy_vdr/src/ledger/request_builder.rs
@@ -130,7 +130,7 @@ impl RequestBuilder {
         verkey: Option<String>,
         alias: Option<String>,
         role: Option<String>,
-        diddoc_content: Option<::serde_json::Value>,
+        diddoc_content: Option<&SJsonValue>,
         version: Option<i32>,
     ) -> VdrResult<PreparedRequest> {
         let role = role_to_code(role)?;
@@ -139,7 +139,7 @@ impl RequestBuilder {
             verkey,
             alias,
             role,
-            diddoc_content,
+            diddoc_content.map(SJsonValue::to_string),
             version,
         );
         self.build(operation, Some(identifier))

--- a/libindy_vdr/src/ledger/requests/nym.rs
+++ b/libindy_vdr/src/ledger/requests/nym.rs
@@ -18,7 +18,7 @@ pub struct NymOperation {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub role: Option<::serde_json::Value>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub diddoc_content: Option<::serde_json::Value>,
+    pub diddoc_content: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub version: Option<i32>,
 }
@@ -29,7 +29,7 @@ impl NymOperation {
         verkey: Option<String>,
         alias: Option<String>,
         role: Option<::serde_json::Value>,
-        diddoc_content: Option<::serde_json::Value>,
+        diddoc_content: Option<String>,
         version: Option<i32>,
     ) -> NymOperation {
         NymOperation {

--- a/libindy_vdr/src/ledger/responses.rs
+++ b/libindy_vdr/src/ledger/responses.rs
@@ -1,6 +1,5 @@
 use crate::utils::did::DidValue;
 use serde::Deserialize;
-use serde_json::Value as SJsonValue;
 use std::collections::HashMap;
 
 pub enum ResponseTypes {
@@ -16,7 +15,7 @@ pub enum GetNymResult {
     GetNymResultV1(GetNymResultV1),
 }
 
-#[derive(Deserialize, Eq, PartialEq, Debug)]
+#[derive(Serialize, Deserialize, Eq, PartialEq, Debug)]
 pub struct GetNymResultV0 {
     pub identifier: Option<DidValue>,
     pub dest: DidValue,
@@ -24,14 +23,16 @@ pub struct GetNymResultV0 {
     pub verkey: String,
 }
 
-#[derive(Deserialize, Eq, PartialEq, Debug)]
+#[derive(Serialize, Deserialize, Eq, PartialEq, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct GetNymResultV1 {
     pub identifier: Option<DidValue>,
     pub dest: DidValue,
     pub role: Option<String>,
     pub verkey: String,
-    pub diddoc_content: Option<SJsonValue>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub diddoc_content: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub version: Option<i32>,
 }
 

--- a/libindy_vdr/src/resolver/did_document.rs
+++ b/libindy_vdr/src/resolver/did_document.rs
@@ -9,20 +9,20 @@ pub const DID_CORE_CONTEXT: &str = "https://www.w3.org/ns/did/v1";
 #[derive(Serialize, PartialEq, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct Ed25519VerificationKey2018 {
-    pub id: String,
-    pub type_: String,
-    pub controller: String,
-    pub public_key_base58: String,
+    id: String,
+    type_: String,
+    controller: String,
+    public_key_base58: String,
 }
 
 #[derive(Serialize, Deserialize, PartialEq, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct DidCommService {
-    pub id: String,
-    pub type_: String,
-    pub recipient_keys: Vec<String>,
-    pub routing_keys: Vec<String>,
-    pub priority: u8,
+    id: String,
+    type_: String,
+    recipient_keys: Vec<String>,
+    routing_keys: Vec<String>,
+    priority: u8,
 }
 
 impl DidCommService {
@@ -40,9 +40,9 @@ impl DidCommService {
 #[derive(Serialize, Deserialize, PartialEq, Debug)]
 #[serde(rename_all = "camelCase")]
 struct GenericService {
-    pub id: String,
-    pub type_: String,
-    pub service_endpoint: String,
+    id: String,
+    type_: String,
+    service_endpoint: String,
 }
 
 #[derive(Serialize, Deserialize, PartialEq, Debug)]
@@ -51,8 +51,8 @@ pub struct DidDocument {
     namespace: String,
     id: String,
     verkey: String,
-    endpoint: Option<Endpoint>,
-    diddoc_content: Option<SJsonValue>,
+    pub endpoint: Option<Endpoint>,
+    pub diddoc_content: Option<SJsonValue>,
 }
 
 impl DidDocument {

--- a/libindy_vdr/src/resolver/mod.rs
+++ b/libindy_vdr/src/resolver/mod.rs
@@ -1,6 +1,8 @@
-mod resolver;
+pub mod resolver;
 
 pub mod did;
 pub mod did_document;
+pub mod types;
+pub mod utils;
 
 pub use self::resolver::{PoolResolver, PoolRunnerResolver};

--- a/libindy_vdr/src/resolver/resolver.rs
+++ b/libindy_vdr/src/resolver/resolver.rs
@@ -24,6 +24,13 @@ pub enum Result {
 
 #[derive(Serialize, Deserialize, PartialEq, Debug)]
 #[serde(rename_all = "camelCase")]
+pub enum Metadata {
+    DidDocumentMetadata(DidDocumentMetadata),
+    ContentMetadata(ContentMetadata),
+}
+
+#[derive(Serialize, Deserialize, PartialEq, Debug)]
+#[serde(rename_all = "camelCase")]
 pub struct ContentMetadata {
     node_response: SJsonValue,
     object_type: String,
@@ -31,10 +38,18 @@ pub struct ContentMetadata {
 
 #[derive(Serialize, Deserialize, PartialEq, Debug)]
 #[serde(rename_all = "camelCase")]
+pub struct DidDocumentMetadata {
+    node_response: SJsonValue,
+    object_type: String,
+    self_certification_version: Option<i32>,
+}
+
+#[derive(Serialize, Deserialize, PartialEq, Debug)]
+#[serde(rename_all = "camelCase")]
 pub struct ResolutionResult {
     did_resolution_metadata: Option<String>,
     did_document: Option<SJsonValue>,
-    did_document_metadata: Option<ContentMetadata>,
+    did_document_metadata: Option<DidDocumentMetadata>,
 }
 
 #[derive(Serialize, Deserialize, PartialEq, Debug)]
@@ -65,10 +80,16 @@ impl<T: Pool> PoolResolver<T> {
             _ => None,
         };
 
+        let md = if let Metadata::ContentMetadata(md) = metadata {
+            Some(md)
+        } else {
+            None
+        };
+
         let result = DereferencingResult {
             dereferencing_metadata: None,
             content_stream: content,
-            content_metadata: Some(metadata),
+            content_metadata: md,
         };
 
         Ok(serde_json::to_string_pretty(&result).unwrap())
@@ -83,17 +104,24 @@ impl<T: Pool> PoolResolver<T> {
             Result::DidDocument(doc) => Some(doc.to_value()?),
             _ => None,
         };
+
+        let md = if let Metadata::DidDocumentMetadata(md) = metadata {
+            Some(md)
+        } else {
+            None
+        };
+
         let result = ResolutionResult {
             did_resolution_metadata: None,
             did_document: diddoc,
-            did_document_metadata: Some(metadata),
+            did_document_metadata: md,
         };
 
         Ok(serde_json::to_string_pretty(&result).unwrap())
     }
 
     // Internal method to resolve and dereference
-    fn _resolve(&self, did: &str) -> VdrResult<(Result, ContentMetadata)> {
+    fn _resolve(&self, did: &str) -> VdrResult<(Result, Metadata)> {
         let did_url = DidUrl::from_str(did)?;
 
         let builder = self.pool.get_request_builder();
@@ -102,7 +130,7 @@ impl<T: Pool> PoolResolver<T> {
         let ledger_data = self.handle_request(&request)?;
         let data = parse_ledger_data(&ledger_data)?;
 
-        let (result, object_type) = match request.txn_type.as_str() {
+        let (result, metadata) = match request.txn_type.as_str() {
             constants::GET_NYM => {
                 let get_nym_result: GetNymResultV1 =
                     serde_json::from_str(data.as_str().unwrap())
@@ -122,20 +150,50 @@ impl<T: Pool> PoolResolver<T> {
                     endpoint,
                     None,
                 );
-                (Result::DidDocument(did_document), String::from("NYM"))
-            }
-            constants::GET_CRED_DEF => (Result::Content(data), String::from("CRED_DEF")),
-            constants::GET_SCHEMA => (Result::Content(data), String::from("SCHEMA")),
-            constants::GET_REVOC_REG_DEF => (Result::Content(data), String::from("REVOC_REG_DEF")),
-            constants::GET_REVOC_REG_DELTA => {
-                (Result::Content(data), String::from("REVOC_REG_DELTA"))
-            }
-            _ => (Result::Content(data), String::from("UNKOWN")),
-        };
 
-        let metadata = ContentMetadata {
-            node_response: serde_json::from_str(&ledger_data).unwrap(),
-            object_type,
+                let metadata = Metadata::DidDocumentMetadata(DidDocumentMetadata {
+                    node_response: serde_json::from_str(&ledger_data).unwrap(),
+                    object_type: String::from("NYM"),
+                    self_certification_version: get_nym_result.version,
+                });
+
+                (Result::DidDocument(did_document), metadata)
+            }
+            constants::GET_CRED_DEF => (
+                Result::Content(data),
+                Metadata::ContentMetadata(ContentMetadata {
+                    node_response: serde_json::from_str(&ledger_data).unwrap(),
+                    object_type: String::from("CRED_DEF"),
+                }),
+            ),
+            constants::GET_SCHEMA => (
+                Result::Content(data),
+                Metadata::ContentMetadata(ContentMetadata {
+                    node_response: serde_json::from_str(&ledger_data).unwrap(),
+                    object_type: String::from("SCHEMA"),
+                }),
+            ),
+            constants::GET_REVOC_REG_DEF => (
+                Result::Content(data),
+                Metadata::ContentMetadata(ContentMetadata {
+                    node_response: serde_json::from_str(&ledger_data).unwrap(),
+                    object_type: String::from("REVOC_REG_DEF"),
+                }),
+            ),
+            constants::GET_REVOC_REG_DELTA => (
+                Result::Content(data),
+                Metadata::ContentMetadata(ContentMetadata {
+                    node_response: serde_json::from_str(&ledger_data).unwrap(),
+                    object_type: String::from("REVOC_REG_DELTA"),
+                }),
+            ),
+            _ => (
+                Result::Content(data),
+                Metadata::ContentMetadata(ContentMetadata {
+                    node_response: serde_json::from_str(&ledger_data).unwrap(),
+                    object_type: String::from("REVOC_REG_DELTA"),
+                }),
+            ),
         };
 
         let result_with_metadata = (result, metadata);
@@ -200,10 +258,16 @@ impl<'a> PoolRunnerResolver<'a> {
                     _ => None,
                 };
 
+                let md = if let Metadata::ContentMetadata(md) = metadata {
+                    Some(md)
+                } else {
+                    None
+                };
+
                 let result = DereferencingResult {
                     dereferencing_metadata: None,
                     content_stream: content,
-                    content_metadata: Some(metadata),
+                    content_metadata: md,
                 };
 
                 callback(Ok(serde_json::to_string_pretty(&result).unwrap()))
@@ -221,10 +285,17 @@ impl<'a> PoolRunnerResolver<'a> {
                     Result::DidDocument(doc) => Some(doc.to_value().unwrap()),
                     _ => None,
                 };
+
+                let md = if let Metadata::DidDocumentMetadata(md) = metadata {
+                    Some(md)
+                } else {
+                    None
+                };
+
                 let result = ResolutionResult {
                     did_resolution_metadata: None,
                     did_document: diddoc,
-                    did_document_metadata: Some(metadata),
+                    did_document_metadata: md,
                 };
 
                 callback(Ok(serde_json::to_string_pretty(&result).unwrap()))
@@ -233,10 +304,11 @@ impl<'a> PoolRunnerResolver<'a> {
     }
 
     // TODO: Refactor
+    // TODO: Adapt according to PoolResolver.
     fn _resolve(
         &self,
         did: &str,
-        callback: Box<dyn (FnOnce(VdrResult<(Result, ContentMetadata)>) -> ()) + Send + 'static>,
+        callback: Callback<VdrResult<(Result, Metadata)>>,
     ) -> VdrResult<()> {
         let did_url = DidUrl::from_str(did)?;
 
@@ -297,50 +369,74 @@ impl<'a> PoolRunnerResolver<'a> {
                                             None,
                                         );
 
-                                        let metadata = ContentMetadata {
-                                            node_response: serde_json::from_str(&reply_data)
-                                                .unwrap(),
-                                            object_type: String::from("NYM"),
-                                        };
+                                        let metadata =
+                                            Metadata::DidDocumentMetadata(DidDocumentMetadata {
+                                                node_response: serde_json::from_str(&reply_data)
+                                                    .unwrap(),
+                                                object_type: String::from("NYM"),
+                                                self_certification_version: get_nym_result.version,
+                                            });
 
                                         let result = Some(Result::DidDocument(did_document));
 
                                         let result_with_metadata = (result.unwrap(), metadata);
                                         callback(Ok(result_with_metadata));
                                     } else {
-                                        let (result, object_type) = match txn_type.as_str() {
+                                        let (result, metadata) = match txn_type.as_str() {
                                             constants::GET_CRED_DEF => (
-                                                Some(Result::Content(data)),
-                                                String::from("CRED_DEF"),
+                                                Result::Content(data),
+                                                Metadata::ContentMetadata(ContentMetadata {
+                                                    node_response: serde_json::from_str(
+                                                        &reply_data,
+                                                    )
+                                                    .unwrap(),
+                                                    object_type: String::from("CRED_DEF"),
+                                                }),
                                             ),
                                             constants::GET_SCHEMA => (
-                                                Some(Result::Content(data)),
-                                                String::from("SCHEMA"),
+                                                Result::Content(data),
+                                                Metadata::ContentMetadata(ContentMetadata {
+                                                    node_response: serde_json::from_str(
+                                                        &reply_data,
+                                                    )
+                                                    .unwrap(),
+                                                    object_type: String::from("SCHEMA"),
+                                                }),
                                             ),
                                             constants::GET_REVOC_REG_DEF => (
-                                                Some(Result::Content(data)),
-                                                String::from("REVOC_REG_DEF"),
+                                                Result::Content(data),
+                                                Metadata::ContentMetadata(ContentMetadata {
+                                                    node_response: serde_json::from_str(
+                                                        &reply_data,
+                                                    )
+                                                    .unwrap(),
+                                                    object_type: String::from("REVOC_REG_DEF"),
+                                                }),
                                             ),
                                             constants::GET_REVOC_REG_DELTA => (
-                                                Some(Result::Content(data)),
-                                                String::from("REVOC_REG_DELTA"),
+                                                Result::Content(data),
+                                                Metadata::ContentMetadata(ContentMetadata {
+                                                    node_response: serde_json::from_str(
+                                                        &reply_data,
+                                                    )
+                                                    .unwrap(),
+                                                    object_type: String::from("REVOC_REG_DELTA"),
+                                                }),
                                             ),
                                             _ => (
-                                                Some(Result::Content(data)),
-                                                String::from("UNKOWN"),
+                                                Result::Content(data),
+                                                Metadata::ContentMetadata(ContentMetadata {
+                                                    node_response: serde_json::from_str(
+                                                        &reply_data,
+                                                    )
+                                                    .unwrap(),
+                                                    object_type: String::from("REVOC_REG_DELTA"),
+                                                }),
                                             ),
                                         };
 
-                                        let metadata = ContentMetadata {
-                                            node_response: serde_json::from_str(&reply_data)
-                                                .unwrap(),
-                                            object_type,
-                                        };
-
-                                        if result.is_some() {
-                                            let result_with_metadata = (result.unwrap(), metadata);
-                                            callback(Ok(result_with_metadata));
-                                        }
+                                        let result_with_metadata = (result, metadata);
+                                        callback(Ok(result_with_metadata));
                                     }
                                 }
                                 RequestResult::Failed(err) => callback(Err(err)),

--- a/libindy_vdr/src/resolver/resolver.rs
+++ b/libindy_vdr/src/resolver/resolver.rs
@@ -1,64 +1,11 @@
-use crate::utils::Qualifiable;
-use futures_executor::block_on;
-use serde_json::Value as SJsonValue;
-use time::format_description::well_known::Rfc3339;
-use time::OffsetDateTime;
+use super::did::DidUrl;
+use super::types::*;
+use super::utils::*;
 
-use super::did::{DidUrl, LedgerObject, QueryParameter};
-use super::did_document::{DidDocument, LEGACY_INDY_SERVICE};
 use crate::common::error::prelude::*;
-use crate::ledger::responses::{Endpoint, GetNymResultV1};
 
-use crate::ledger::identifiers::{CredentialDefinitionId, RevocationRegistryId, SchemaId};
-use crate::ledger::{constants, RequestBuilder};
-use crate::pool::helpers::perform_ledger_request;
-use crate::pool::{Pool, PoolRunner, PreparedRequest, RequestResult, TimingResult};
-use crate::utils::did::DidValue;
-
-#[derive(Serialize, Deserialize, PartialEq, Debug)]
-#[serde(rename_all = "camelCase")]
-pub enum Result {
-    DidDocument(DidDocument),
-    Content(SJsonValue),
-}
-
-#[derive(Serialize, Deserialize, PartialEq, Debug)]
-#[serde(rename_all = "camelCase")]
-pub enum Metadata {
-    DidDocumentMetadata(DidDocumentMetadata),
-    ContentMetadata(ContentMetadata),
-}
-
-#[derive(Serialize, Deserialize, PartialEq, Debug)]
-#[serde(rename_all = "camelCase")]
-pub struct ContentMetadata {
-    node_response: SJsonValue,
-    object_type: String,
-}
-
-#[derive(Serialize, Deserialize, PartialEq, Debug)]
-#[serde(rename_all = "camelCase")]
-pub struct DidDocumentMetadata {
-    node_response: SJsonValue,
-    object_type: String,
-    self_certification_version: Option<i32>,
-}
-
-#[derive(Serialize, Deserialize, PartialEq, Debug)]
-#[serde(rename_all = "camelCase")]
-pub struct ResolutionResult {
-    did_resolution_metadata: Option<String>,
-    did_document: Option<SJsonValue>,
-    did_document_metadata: Option<DidDocumentMetadata>,
-}
-
-#[derive(Serialize, Deserialize, PartialEq, Debug)]
-#[serde(rename_all = "camelCase")]
-pub struct DereferencingResult {
-    dereferencing_metadata: Option<String>,
-    content_stream: Option<SJsonValue>,
-    content_metadata: Option<ContentMetadata>,
-}
+use crate::ledger::RequestBuilder;
+use crate::pool::{Pool, PoolRunner, RequestResult, TimingResult};
 
 /// DID (URL) Resolver interface for a pool compliant with did:indy method spec
 pub struct PoolResolver<T: Pool> {
@@ -71,9 +18,10 @@ impl<T: Pool> PoolResolver<T> {
     }
 
     /// Dereference a DID Url and return a serialized `DereferencingResult`
-    pub fn dereference(&self, did_url: &str) -> VdrResult<String> {
+    pub async fn dereference(&self, did_url: &str) -> VdrResult<String> {
         debug!("PoolResolver: Dereference DID Url {}", did_url);
-        let (data, metadata) = self._resolve(did_url)?;
+        let did_url = DidUrl::from_str(did_url)?;
+        let (data, metadata) = self._resolve(&did_url).await?;
 
         let content = match data {
             Result::Content(c) => Some(c),
@@ -96,12 +44,19 @@ impl<T: Pool> PoolResolver<T> {
     }
 
     /// Resolve a DID and return a serialized `ResolutionResult`
-    pub fn resolve(&self, did: &str) -> VdrResult<String> {
+    pub async fn resolve(&self, did: &str) -> VdrResult<String> {
         debug!("PoolResolver: Resolve DID {}", did);
-        let (data, metadata) = self._resolve(did)?;
+        let did = DidUrl::from_str(did)?;
+        let (data, metadata) = self._resolve(&did).await?;
 
         let diddoc = match data {
-            Result::DidDocument(doc) => Some(doc.to_value()?),
+            Result::DidDocument(mut doc) => {
+                // Try to find legacy endpoint using a GET_ATTRIB txn if diddoc_content is none
+                if doc.diddoc_content.is_none() {
+                    doc.endpoint = fetch_legacy_endpoint(&self.pool, &did.id).await.ok();
+                }
+                Some(doc.to_value()?)
+            }
             _ => None,
         };
 
@@ -121,115 +76,16 @@ impl<T: Pool> PoolResolver<T> {
     }
 
     // Internal method to resolve and dereference
-    fn _resolve(&self, did: &str) -> VdrResult<(Result, Metadata)> {
-        let did_url = DidUrl::from_str(did)?;
-
+    async fn _resolve(&self, did_url: &DidUrl) -> VdrResult<(Result, Metadata)> {
         let builder = self.pool.get_request_builder();
         let request = build_request(&did_url, &builder)?;
 
-        let ledger_data = self.handle_request(&request)?;
-        let data = parse_ledger_data(&ledger_data)?;
+        let ledger_data = handle_request(&self.pool, &request).await?;
+        let txn_type = request.txn_type.as_str();
+        let namespace = did_url.namespace.clone();
+        let result = handle_resolution_result(namespace.as_str(), &ledger_data, txn_type)?;
 
-        let (result, metadata) = match request.txn_type.as_str() {
-            constants::GET_NYM => {
-                let get_nym_result: GetNymResultV1 =
-                    serde_json::from_str(data.as_str().unwrap())
-                        .map_err(|_| err_msg(VdrErrorKind::Resolver, "Could not parse NYM data"))?;
-
-                let endpoint: Option<Endpoint> = if get_nym_result.diddoc_content.is_none() {
-                    // Legacy: Try to find an attached ATTRIBUTE transacation with raw endpoint
-                    self.fetch_legacy_endpoint(&did_url.id).ok()
-                } else {
-                    None
-                };
-
-                let did_document = DidDocument::new(
-                    &did_url.namespace,
-                    &get_nym_result.dest,
-                    &get_nym_result.verkey,
-                    endpoint,
-                    None,
-                );
-
-                let metadata = Metadata::DidDocumentMetadata(DidDocumentMetadata {
-                    node_response: serde_json::from_str(&ledger_data).unwrap(),
-                    object_type: String::from("NYM"),
-                    self_certification_version: get_nym_result.version,
-                });
-
-                (Result::DidDocument(did_document), metadata)
-            }
-            constants::GET_CRED_DEF => (
-                Result::Content(data),
-                Metadata::ContentMetadata(ContentMetadata {
-                    node_response: serde_json::from_str(&ledger_data).unwrap(),
-                    object_type: String::from("CRED_DEF"),
-                }),
-            ),
-            constants::GET_SCHEMA => (
-                Result::Content(data),
-                Metadata::ContentMetadata(ContentMetadata {
-                    node_response: serde_json::from_str(&ledger_data).unwrap(),
-                    object_type: String::from("SCHEMA"),
-                }),
-            ),
-            constants::GET_REVOC_REG_DEF => (
-                Result::Content(data),
-                Metadata::ContentMetadata(ContentMetadata {
-                    node_response: serde_json::from_str(&ledger_data).unwrap(),
-                    object_type: String::from("REVOC_REG_DEF"),
-                }),
-            ),
-            constants::GET_REVOC_REG_DELTA => (
-                Result::Content(data),
-                Metadata::ContentMetadata(ContentMetadata {
-                    node_response: serde_json::from_str(&ledger_data).unwrap(),
-                    object_type: String::from("REVOC_REG_DELTA"),
-                }),
-            ),
-            _ => (
-                Result::Content(data),
-                Metadata::ContentMetadata(ContentMetadata {
-                    node_response: serde_json::from_str(&ledger_data).unwrap(),
-                    object_type: String::from("REVOC_REG_DELTA"),
-                }),
-            ),
-        };
-
-        let result_with_metadata = (result, metadata);
-
-        Ok(result_with_metadata)
-    }
-
-    fn fetch_legacy_endpoint(&self, did: &DidValue) -> VdrResult<Endpoint> {
-        let builder = self.pool.get_request_builder();
-        let request = builder.build_get_attrib_request(
-            None,
-            did,
-            Some(String::from(LEGACY_INDY_SERVICE)),
-            None,
-            None,
-        )?;
-        let ledger_data = self.handle_request(&request)?;
-        let endpoint_data = parse_ledger_data(&ledger_data)?;
-        let endpoint_data: Endpoint = serde_json::from_str(endpoint_data.as_str().unwrap())
-            .map_err(|_| err_msg(VdrErrorKind::Resolver, "Could not parse endpoint data"))?;
-        Ok(endpoint_data)
-    }
-
-    fn handle_request(&self, request: &PreparedRequest) -> VdrResult<String> {
-        let (result, _timing) = block_on(self.request_transaction(&request))?;
-        match result {
-            RequestResult::Reply(data) => Ok(data),
-            RequestResult::Failed(error) => Err(error),
-        }
-    }
-
-    async fn request_transaction(
-        &self,
-        request: &PreparedRequest,
-    ) -> VdrResult<(RequestResult<String>, Option<TimingResult>)> {
-        perform_ledger_request(&self.pool, &request).await
+        Ok(result)
     }
 }
 
@@ -249,8 +105,9 @@ impl<'a> PoolRunnerResolver<'a> {
         did_url: &str,
         callback: Callback<VdrResult<String>>,
     ) -> VdrResult<()> {
+        let did_url = DidUrl::from_str(did_url)?;
         self._resolve(
-            did_url,
+            &did_url,
             Box::new(move |result| {
                 let (data, metadata) = result.unwrap();
                 let content = match data {
@@ -277,502 +134,121 @@ impl<'a> PoolRunnerResolver<'a> {
 
     /// Resolve a DID and return a serialized `ResolutionResult`
     pub fn resolve(&self, did: &str, callback: Callback<VdrResult<String>>) -> VdrResult<()> {
+        let did = DidUrl::from_str(did)?;
         self._resolve(
-            did,
+            &did,
             Box::new(move |result| {
-                let (data, metadata) = result.unwrap();
-                let diddoc = match data {
-                    Result::DidDocument(doc) => Some(doc.to_value().unwrap()),
-                    _ => None,
-                };
+                match result {
+                    Ok((data, metadata)) => {
+                        match data {
+                            // TODO: Doc needs to be mutable, when we uncomment
+                            Result::DidDocument(doc) => {
+                                // Try to find legacy endpoint using a GET_ATTRIB txn if diddoc_content is none
+                                if doc.diddoc_content.is_none() {
+                                    // let did_copy = did.id.clone();
+                                    // fetch_legacy_endpoint_with_runner(
+                                    //     self.runner,
+                                    //     &did_copy,
+                                    //     Box::new(|result| {
+                                    //         doc.endpoint = result.ok();
+                                    //         let diddoc = Some(doc.to_value().unwrap());
+                                    //         let md = if let Metadata::DidDocumentMetadata(md) =
+                                    //             metadata
+                                    //         {
+                                    //             Some(md)
+                                    //         } else {
+                                    //             None
+                                    //         };
 
-                let md = if let Metadata::DidDocumentMetadata(md) = metadata {
-                    Some(md)
-                } else {
-                    None
-                };
+                                    //         let result = ResolutionResult {
+                                    //             did_resolution_metadata: None,
+                                    //             did_document: diddoc,
+                                    //             did_document_metadata: md,
+                                    //         };
 
-                let result = ResolutionResult {
-                    did_resolution_metadata: None,
-                    did_document: diddoc,
-                    did_document_metadata: md,
-                };
+                                    //         callback(Ok(
+                                    //             serde_json::to_string_pretty(&result).unwrap()
+                                    //         ))
+                                    //     }),
+                                    // );
+                                } else {
+                                    // let diddoc = Some(doc.to_value().unwrap());
+                                    // let md = if let Metadata::DidDocumentMetadata(md) = metadata {
+                                    //     Some(md)
+                                    // } else {
+                                    //     None
+                                    // };
 
-                callback(Ok(serde_json::to_string_pretty(&result).unwrap()))
+                                    // let result = ResolutionResult {
+                                    //     did_resolution_metadata: None,
+                                    //     did_document: diddoc,
+                                    //     did_document_metadata: md,
+                                    // };
+
+                                    //     callback(Ok(serde_json::to_string_pretty(&result).unwrap()))
+                                }
+
+                                // For now, until if/else above is used
+
+                                let diddoc = Some(doc.to_value().unwrap());
+                                let md = if let Metadata::DidDocumentMetadata(md) = metadata {
+                                    Some(md)
+                                } else {
+                                    None
+                                };
+
+                                let result = ResolutionResult {
+                                    did_resolution_metadata: None,
+                                    did_document: diddoc,
+                                    did_document_metadata: md,
+                                };
+
+                                callback(Ok(serde_json::to_string_pretty(&result).unwrap()))
+                            }
+                            _ => {}
+                        };
+                    }
+                    // TODO: How to handle errors?
+                    Err(_err) => {}
+                }
             }),
-        )
+        )?;
+        Ok(())
     }
 
-    // TODO: Refactor
-    // TODO: Adapt according to PoolResolver.
     fn _resolve(
         &self,
-        did: &str,
+        did_url: &DidUrl,
         callback: Callback<VdrResult<(Result, Metadata)>>,
     ) -> VdrResult<()> {
-        let did_url = DidUrl::from_str(did)?;
+        let namespace = did_url.namespace.clone();
 
         let builder = RequestBuilder::default();
         let request = build_request(&did_url, &builder)?;
         let txn_type = request.txn_type.clone();
+
         self.runner.send_request(
             request,
             Box::new(
                 move |result: VdrResult<(RequestResult<String>, Option<TimingResult>)>| {
-                    match result {
-                        Ok((reply, _)) => {
-                            match reply {
-                                RequestResult::Reply(reply_data) => {
-                                    let data = parse_ledger_data(&reply_data).unwrap();
-                                    if txn_type.as_str() == constants::GET_NYM {
-                                        let get_nym_result: GetNymResultV1 =
-                                            serde_json::from_str(data.as_str().unwrap()).unwrap();
-
-                                        // TODO: Fix fetch_legacy_endpoint
-                                        // let did = did_url.id.clone();
-                                        if get_nym_result.diddoc_content.is_none() {
-                                            // Legacy: Try to find an attached ATTRIBUTE transacation with raw endpoint
-                                            // self._fetch_legacy_endpoint(
-                                            //     &did,
-                                            //     Box::new(move |result| {
-                                            //         let did_document = DidDocument::new(
-                                            //             &did_url.namespace,
-                                            //             &get_nym_result.dest,
-                                            //             &get_nym_result.verkey,
-                                            //             result.ok(),
-                                            //             None,
-                                            //         );
-
-                                            //         let metadata = ContentMetadata {
-                                            //             node_response: serde_json::from_str(
-                                            //                 &reply_data,
-                                            //             )
-                                            //             .unwrap(),
-                                            //             object_type: String::from("NYM"),
-                                            //         };
-
-                                            //         let result =
-                                            //             Some(Result::DidDocument(did_document));
-
-                                            //         let result_with_metadata =
-                                            //             (result.unwrap(), metadata);
-                                            //         callback(Ok(result_with_metadata));
-                                            //     }),
-                                            // );
-                                        }
-
-                                        let did_document = DidDocument::new(
-                                            &did_url.namespace,
-                                            &get_nym_result.dest,
-                                            &get_nym_result.verkey,
-                                            None,
-                                            None,
-                                        );
-
-                                        let metadata =
-                                            Metadata::DidDocumentMetadata(DidDocumentMetadata {
-                                                node_response: serde_json::from_str(&reply_data)
-                                                    .unwrap(),
-                                                object_type: String::from("NYM"),
-                                                self_certification_version: get_nym_result.version,
-                                            });
-
-                                        let result = Some(Result::DidDocument(did_document));
-
-                                        let result_with_metadata = (result.unwrap(), metadata);
-                                        callback(Ok(result_with_metadata));
-                                    } else {
-                                        let (result, metadata) = match txn_type.as_str() {
-                                            constants::GET_CRED_DEF => (
-                                                Result::Content(data),
-                                                Metadata::ContentMetadata(ContentMetadata {
-                                                    node_response: serde_json::from_str(
-                                                        &reply_data,
-                                                    )
-                                                    .unwrap(),
-                                                    object_type: String::from("CRED_DEF"),
-                                                }),
-                                            ),
-                                            constants::GET_SCHEMA => (
-                                                Result::Content(data),
-                                                Metadata::ContentMetadata(ContentMetadata {
-                                                    node_response: serde_json::from_str(
-                                                        &reply_data,
-                                                    )
-                                                    .unwrap(),
-                                                    object_type: String::from("SCHEMA"),
-                                                }),
-                                            ),
-                                            constants::GET_REVOC_REG_DEF => (
-                                                Result::Content(data),
-                                                Metadata::ContentMetadata(ContentMetadata {
-                                                    node_response: serde_json::from_str(
-                                                        &reply_data,
-                                                    )
-                                                    .unwrap(),
-                                                    object_type: String::from("REVOC_REG_DEF"),
-                                                }),
-                                            ),
-                                            constants::GET_REVOC_REG_DELTA => (
-                                                Result::Content(data),
-                                                Metadata::ContentMetadata(ContentMetadata {
-                                                    node_response: serde_json::from_str(
-                                                        &reply_data,
-                                                    )
-                                                    .unwrap(),
-                                                    object_type: String::from("REVOC_REG_DELTA"),
-                                                }),
-                                            ),
-                                            _ => (
-                                                Result::Content(data),
-                                                Metadata::ContentMetadata(ContentMetadata {
-                                                    node_response: serde_json::from_str(
-                                                        &reply_data,
-                                                    )
-                                                    .unwrap(),
-                                                    object_type: String::from("REVOC_REG_DELTA"),
-                                                }),
-                                            ),
-                                        };
-
-                                        let result_with_metadata = (result, metadata);
-                                        callback(Ok(result_with_metadata));
-                                    }
-                                }
-                                RequestResult::Failed(err) => callback(Err(err)),
-                            }
-                        }
-                        Err(err) => callback(Err(err)),
+                    let ledger_data = match result {
+                        Ok((reply, _)) => match reply {
+                            RequestResult::Reply(reply_data) => Ok(reply_data),
+                            RequestResult::Failed(err) => Err(err),
+                        },
+                        Err(err) => Err(err),
                     }
+                    .unwrap();
+
+                    let result = handle_resolution_result(
+                        namespace.as_str(),
+                        &ledger_data,
+                        txn_type.as_str(),
+                    )
+                    .unwrap();
+                    callback(Ok(result))
                 },
             ),
         )
-    }
-
-    fn _fetch_legacy_endpoint(
-        &self,
-        did: &DidValue,
-        callback: Callback<VdrResult<Endpoint>>,
-    ) -> VdrResult<()> {
-        let builder = RequestBuilder::default();
-        let request = builder.build_get_attrib_request(
-            None,
-            did,
-            Some(String::from(LEGACY_INDY_SERVICE)),
-            None,
-            None,
-        )?;
-        self.runner.send_request(
-            request,
-            Box::new(move |result| match result {
-                Ok((res, _)) => match res {
-                    RequestResult::Reply(reply_data) => {
-                        let endpoint_data = parse_ledger_data(&reply_data).unwrap();
-                        let endpoint_data: Endpoint =
-                            serde_json::from_str(endpoint_data.as_str().unwrap()).unwrap();
-                        callback(Ok(endpoint_data));
-                    }
-                    RequestResult::Failed(err) => callback(Err(err)),
-                },
-                Err(err) => callback(Err(err)),
-            }),
-        )
-    }
-}
-
-type Callback<R> = Box<dyn (FnOnce(R) -> ()) + Send>;
-
-fn build_request(did: &DidUrl, builder: &RequestBuilder) -> VdrResult<PreparedRequest> {
-    let request = if did.path.is_some() {
-        match LedgerObject::from_str(did.path.as_ref().unwrap().as_str())? {
-            LedgerObject::Schema(schema) => builder.build_get_schema_request(
-                None,
-                &SchemaId::new(&did.id, &schema.name, &schema.version),
-            ),
-            LedgerObject::ClaimDef(claim_def) => builder.build_get_cred_def_request(
-                None,
-                &CredentialDefinitionId::from_str(
-                    format!(
-                        "{}:3:CL:{}:{}",
-                        &did.id, claim_def.schema_seq_no, claim_def.name
-                    )
-                    .as_str(),
-                )
-                .unwrap(),
-            ),
-            LedgerObject::RevRegDef(rev_reg_def) => builder.build_get_revoc_reg_def_request(
-                None,
-                &RevocationRegistryId::from_str(
-                    format!(
-                        "{}:4:{}:3:CL:{}:{}:CL_ACCUM:{}",
-                        &did.id,
-                        &did.id,
-                        rev_reg_def.schema_seq_no,
-                        rev_reg_def.claim_def_name,
-                        rev_reg_def.tag
-                    )
-                    .as_str(),
-                )
-                .unwrap(),
-            ),
-            LedgerObject::RevRegEntry(rev_reg_entry) => {
-                // If From or To parameters, return RevRegDelta request
-                if did.query.contains_key(&QueryParameter::From)
-                    || did.query.contains_key(&QueryParameter::To)
-                {
-                    let mut from: Option<i64> = None;
-                    if did.query.contains_key(&QueryParameter::From) {
-                        from = did
-                            .query
-                            .get(&QueryParameter::From)
-                            .and_then(|d| OffsetDateTime::parse(d, &Rfc3339).ok())
-                            .and_then(|d| Some(d.unix_timestamp()));
-                    }
-
-                    let to = parse_or_now(did.query.get(&QueryParameter::To))?;
-
-                    builder.build_get_revoc_reg_delta_request(
-                        None,
-                        &RevocationRegistryId::from_str(
-                            format!(
-                                "{}:4:{}:3:CL:{}:{}:CL_ACCUM:{}",
-                                &did.id,
-                                &did.id,
-                                rev_reg_entry.schema_seq_no,
-                                rev_reg_entry.claim_def_name,
-                                rev_reg_entry.tag
-                            )
-                            .as_str(),
-                        )
-                        .unwrap(),
-                        from,
-                        to,
-                    )
-                // Else return RevRegEntry request
-                } else {
-                    let timestamp = parse_or_now(did.query.get(&QueryParameter::VersionTime))?;
-
-                    builder.build_get_revoc_reg_request(
-                        None,
-                        &RevocationRegistryId::from_str(
-                            format!(
-                                "{}:4:{}:3:CL:{}:{}:CL_ACCUM:{}",
-                                &did.id,
-                                &did.id,
-                                rev_reg_entry.schema_seq_no,
-                                rev_reg_entry.claim_def_name,
-                                rev_reg_entry.tag
-                            )
-                            .as_str(),
-                        )
-                        .unwrap(),
-                        timestamp,
-                    )
-                }
-            }
-            // This path is deprecated. Deltas can be retrieved through RevRegEntry
-            LedgerObject::RevRegDelta(rev_reg_delta) => {
-                let mut from: Option<i64> = None;
-                if did.query.contains_key(&QueryParameter::From) {
-                    from = did
-                        .query
-                        .get(&QueryParameter::From)
-                        .and_then(|d| OffsetDateTime::parse(d, &Rfc3339).ok())
-                        .and_then(|d| Some(d.unix_timestamp()));
-                }
-
-                let to = parse_or_now(did.query.get(&QueryParameter::To))?;
-
-                builder.build_get_revoc_reg_delta_request(
-                    None,
-                    &RevocationRegistryId::from_str(
-                        format!(
-                            "{}:4:{}:3:CL:{}:{}:CL_ACCUM:{}",
-                            &did.id,
-                            &did.id,
-                            rev_reg_delta.schema_seq_no,
-                            rev_reg_delta.claim_def_name,
-                            rev_reg_delta.tag
-                        )
-                        .as_str(),
-                    )
-                    .unwrap(),
-                    from,
-                    to,
-                )
-            }
-        }
-    } else {
-        let seq_no: Option<i32> = did
-            .query
-            .get(&QueryParameter::VersionId)
-            .and_then(|v| v.parse().ok());
-        let timestamp: Option<u64> = did
-            .query
-            .get(&QueryParameter::VersionTime)
-            .and_then(|d| OffsetDateTime::parse(d, &Rfc3339).ok())
-            .and_then(|d| Some(d.unix_timestamp()))
-            .and_then(|d| Some(d as u64));
-
-        builder.build_get_nym_request(Option::None, &did.id, seq_no, timestamp)
-    };
-    request
-}
-
-fn parse_ledger_data(ledger_data: &str) -> VdrResult<SJsonValue> {
-    let v: SJsonValue = serde_json::from_str(&ledger_data)
-        .map_err(|_| err_msg(VdrErrorKind::Resolver, "Could not parse ledger response"))?;
-    let data: &SJsonValue = &v["result"]["data"];
-    if *data == SJsonValue::Null {
-        Err(err_msg(
-            VdrErrorKind::Resolver,
-            format!("Empty data in ledger response"),
-        ))
-    } else {
-        Ok(data.to_owned())
-    }
-}
-
-fn parse_or_now(datetime: Option<&String>) -> VdrResult<i64> {
-    match datetime {
-        Some(datetime) => {
-            let dt = OffsetDateTime::parse(datetime, &Rfc3339).map_err(|_| {
-                err_msg(
-                    VdrErrorKind::Resolver,
-                    format!("Could not parse datetime {}", datetime),
-                )
-            })?;
-            Ok(dt.unix_timestamp())
-        }
-        None => Ok(OffsetDateTime::now_utc().unix_timestamp()),
-    }
-}
-
-#[cfg(test)]
-mod tests {
-
-    use urlencoding::encode;
-
-    use super::*;
-    use rstest::*;
-
-    use crate::pool::ProtocolVersion;
-
-    #[fixture]
-    fn request_builder() -> RequestBuilder {
-        RequestBuilder::new(ProtocolVersion::Node1_4)
-    }
-
-    #[rstest]
-    fn build_get_revoc_reg_request_from_version_time(request_builder: RequestBuilder) {
-        let datetime_as_str = "2020-12-20T19:17:47Z";
-        let did_url_as_str = format!("did:indy:idunion:Dk1fRRTtNazyMuK2cr64wp/anoncreds/v0/REV_REG_ENTRY/104/revocable/a4e25e54?versionTime={}",datetime_as_str);
-        let did_url = DidUrl::from_str(&did_url_as_str).unwrap();
-        let request = build_request(&did_url, &request_builder).unwrap();
-        let timestamp = (*(request.req_json).get("operation").unwrap())
-            .get("timestamp")
-            .unwrap()
-            .as_u64()
-            .unwrap() as i64;
-        assert_eq!(constants::GET_REVOC_REG, request.txn_type);
-
-        assert_eq!(
-            OffsetDateTime::parse(datetime_as_str, &Rfc3339)
-                .unwrap()
-                .unix_timestamp(),
-            timestamp
-        );
-    }
-
-    #[rstest]
-    fn build_get_revoc_reg_without_version_time(request_builder: RequestBuilder) {
-        let now = OffsetDateTime::now_utc().unix_timestamp();
-
-        let did_url_as_str = "did:indy:idunion:Dk1fRRTtNazyMuK2cr64wp/anoncreds/v0/REV_REG_ENTRY/104/revocable/a4e25e54";
-        let did_url = DidUrl::from_str(did_url_as_str).unwrap();
-        let request = build_request(&did_url, &request_builder).unwrap();
-        let timestamp = (*(request.req_json).get("operation").unwrap())
-            .get("timestamp")
-            .unwrap()
-            .as_u64()
-            .unwrap() as i64;
-
-        assert_eq!(constants::GET_REVOC_REG, request.txn_type);
-        assert!(timestamp >= now);
-    }
-
-    #[rstest]
-    fn build_get_revoc_reg_request_fails_with_unparsable_version_time(
-        request_builder: RequestBuilder,
-    ) {
-        let datetime_as_str = "20201220T19:17:47Z";
-        let did_url_as_str = format!("did:indy:idunion:Dk1fRRTtNazyMuK2cr64wp/anoncreds/v0/REV_REG_ENTRY/104/revocable/a4e25e54?versionTime={}",datetime_as_str);
-        let did_url = DidUrl::from_str(&did_url_as_str).unwrap();
-        let _err = build_request(&did_url, &request_builder).unwrap_err();
-    }
-
-    #[rstest]
-    fn build_get_revoc_reg_delta_request_with_from_to(request_builder: RequestBuilder) {
-        let from_as_str = "2019-12-20T19:17:47Z";
-        let to_as_str = "2020-12-20T19:17:47Z";
-        let did_url_as_str = format!("did:indy:idunion:Dk1fRRTtNazyMuK2cr64wp/anoncreds/v0/REV_REG_ENTRY/104/revocable/a4e25e54?from={}&to={}",from_as_str, to_as_str);
-        let did_url = DidUrl::from_str(&did_url_as_str).unwrap();
-        let request = build_request(&did_url, &request_builder).unwrap();
-        assert_eq!(request.txn_type, constants::GET_REVOC_REG_DELTA);
-    }
-
-    #[rstest]
-    fn build_get_revoc_reg_delta_request_with_from_only(request_builder: RequestBuilder) {
-        let now = OffsetDateTime::now_utc().unix_timestamp();
-        let from_as_str = "2019-12-20T19:17:47Z";
-        let did_url_as_str = format!("did:indy:idunion:Dk1fRRTtNazyMuK2cr64wp/anoncreds/v0/REV_REG_ENTRY/104/revocable/a4e25e54?from={}",from_as_str);
-        let did_url = DidUrl::from_str(&did_url_as_str).unwrap();
-        let request = build_request(&did_url, &request_builder).unwrap();
-
-        let to = (*(request.req_json).get("operation").unwrap())
-            .get("to")
-            .unwrap()
-            .as_u64()
-            .unwrap() as i64;
-        assert_eq!(request.txn_type, constants::GET_REVOC_REG_DELTA);
-        assert!(to >= now)
-    }
-
-    #[rstest]
-    fn build_get_revoc_reg_delta_request_without_parameter(request_builder: RequestBuilder) {
-        let now = OffsetDateTime::now_utc().unix_timestamp();
-        let did_url_as_str = "did:indy:idunion:Dk1fRRTtNazyMuK2cr64wp/anoncreds/v0/REV_REG_DELTA/104/revocable/a4e25e54";
-        let did_url = DidUrl::from_str(did_url_as_str).unwrap();
-        let request = build_request(&did_url, &request_builder).unwrap();
-
-        let to = (*(request.req_json).get("operation").unwrap())
-            .get("to")
-            .unwrap()
-            .as_u64()
-            .unwrap() as i64;
-
-        let from = (*(request.req_json).get("operation").unwrap()).get("from");
-        assert_eq!(request.txn_type, constants::GET_REVOC_REG_DELTA);
-        assert!(from.is_none());
-        assert!(to >= now);
-    }
-
-    #[rstest]
-    fn build_get_schema_request_with_whitespace(request_builder: RequestBuilder) {
-        let name = "My Schema";
-        let encoded_schema_name = encode(name).to_string();
-        let did_url_string = format!(
-            "did:indy:idunion:Dk1fRRTtNazyMuK2cr64wp/anoncreds/v0/SCHEMA/{}/1.0",
-            encoded_schema_name
-        );
-
-        let did_url = DidUrl::from_str(did_url_string.as_str()).unwrap();
-        let request = build_request(&did_url, &request_builder).unwrap();
-        let schema_name = (*(request.req_json).get("operation").unwrap())
-            .get("data")
-            .and_then(|v| v.get("name"))
-            .and_then(|v| v.as_str())
-            .unwrap();
-        assert_eq!(schema_name, name);
     }
 }

--- a/libindy_vdr/src/resolver/types.rs
+++ b/libindy_vdr/src/resolver/types.rs
@@ -1,0 +1,50 @@
+use serde_json::Value as SJsonValue;
+
+use super::did_document::DidDocument;
+
+pub type Callback<R> = Box<dyn (FnOnce(R) -> ()) + Send>;
+
+#[derive(Serialize, Deserialize, PartialEq, Debug)]
+#[serde(rename_all = "camelCase")]
+pub enum Result {
+    DidDocument(DidDocument),
+    Content(SJsonValue),
+}
+
+#[derive(Serialize, Deserialize, PartialEq, Debug)]
+#[serde(rename_all = "camelCase")]
+pub enum Metadata {
+    DidDocumentMetadata(DidDocumentMetadata),
+    ContentMetadata(ContentMetadata),
+}
+
+#[derive(Serialize, Deserialize, PartialEq, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct ContentMetadata {
+    pub node_response: SJsonValue,
+    pub object_type: String,
+}
+
+#[derive(Serialize, Deserialize, PartialEq, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct DidDocumentMetadata {
+    pub node_response: SJsonValue,
+    pub object_type: String,
+    pub self_certification_version: Option<i32>,
+}
+
+#[derive(Serialize, Deserialize, PartialEq, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct ResolutionResult {
+    pub did_resolution_metadata: Option<String>,
+    pub did_document: Option<SJsonValue>,
+    pub did_document_metadata: Option<DidDocumentMetadata>,
+}
+
+#[derive(Serialize, Deserialize, PartialEq, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct DereferencingResult {
+    pub dereferencing_metadata: Option<String>,
+    pub content_stream: Option<SJsonValue>,
+    pub content_metadata: Option<ContentMetadata>,
+}

--- a/libindy_vdr/src/resolver/utils.rs
+++ b/libindy_vdr/src/resolver/utils.rs
@@ -1,0 +1,442 @@
+use serde_json::Value as SJsonValue;
+use time::format_description::well_known::Rfc3339;
+use time::OffsetDateTime;
+
+use super::did::{DidUrl, LedgerObject, QueryParameter};
+use super::did_document::{DidDocument, LEGACY_INDY_SERVICE};
+use super::types::*;
+
+use crate::common::error::prelude::*;
+use crate::ledger::constants;
+use crate::ledger::identifiers::{CredentialDefinitionId, RevocationRegistryId, SchemaId};
+use crate::ledger::responses::{Endpoint, GetNymResultV1};
+use crate::ledger::RequestBuilder;
+use crate::pool::helpers::perform_ledger_request;
+use crate::pool::{Pool, PoolRunner, PreparedRequest, RequestResult, TimingResult};
+use crate::utils::did::DidValue;
+use crate::utils::Qualifiable;
+
+pub fn build_request(did: &DidUrl, builder: &RequestBuilder) -> VdrResult<PreparedRequest> {
+    let request = if did.path.is_some() {
+        match LedgerObject::from_str(did.path.as_ref().unwrap().as_str())? {
+            LedgerObject::Schema(schema) => builder.build_get_schema_request(
+                None,
+                &SchemaId::new(&did.id, &schema.name, &schema.version),
+            ),
+            LedgerObject::ClaimDef(claim_def) => builder.build_get_cred_def_request(
+                None,
+                &CredentialDefinitionId::from_str(
+                    format!(
+                        "{}:3:CL:{}:{}",
+                        &did.id, claim_def.schema_seq_no, claim_def.name
+                    )
+                    .as_str(),
+                )
+                .unwrap(),
+            ),
+            LedgerObject::RevRegDef(rev_reg_def) => builder.build_get_revoc_reg_def_request(
+                None,
+                &RevocationRegistryId::from_str(
+                    format!(
+                        "{}:4:{}:3:CL:{}:{}:CL_ACCUM:{}",
+                        &did.id,
+                        &did.id,
+                        rev_reg_def.schema_seq_no,
+                        rev_reg_def.claim_def_name,
+                        rev_reg_def.tag
+                    )
+                    .as_str(),
+                )
+                .unwrap(),
+            ),
+            LedgerObject::RevRegEntry(rev_reg_entry) => {
+                // If From or To parameters, return RevRegDelta request
+                if did.query.contains_key(&QueryParameter::From)
+                    || did.query.contains_key(&QueryParameter::To)
+                {
+                    let mut from: Option<i64> = None;
+                    if did.query.contains_key(&QueryParameter::From) {
+                        from = did
+                            .query
+                            .get(&QueryParameter::From)
+                            .and_then(|d| OffsetDateTime::parse(d, &Rfc3339).ok())
+                            .and_then(|d| Some(d.unix_timestamp()));
+                    }
+
+                    let to = parse_or_now(did.query.get(&QueryParameter::To))?;
+
+                    builder.build_get_revoc_reg_delta_request(
+                        None,
+                        &RevocationRegistryId::from_str(
+                            format!(
+                                "{}:4:{}:3:CL:{}:{}:CL_ACCUM:{}",
+                                &did.id,
+                                &did.id,
+                                rev_reg_entry.schema_seq_no,
+                                rev_reg_entry.claim_def_name,
+                                rev_reg_entry.tag
+                            )
+                            .as_str(),
+                        )
+                        .unwrap(),
+                        from,
+                        to,
+                    )
+                // Else return RevRegEntry request
+                } else {
+                    let timestamp = parse_or_now(did.query.get(&QueryParameter::VersionTime))?;
+
+                    builder.build_get_revoc_reg_request(
+                        None,
+                        &RevocationRegistryId::from_str(
+                            format!(
+                                "{}:4:{}:3:CL:{}:{}:CL_ACCUM:{}",
+                                &did.id,
+                                &did.id,
+                                rev_reg_entry.schema_seq_no,
+                                rev_reg_entry.claim_def_name,
+                                rev_reg_entry.tag
+                            )
+                            .as_str(),
+                        )
+                        .unwrap(),
+                        timestamp,
+                    )
+                }
+            }
+            // This path is deprecated. Deltas can be retrieved through RevRegEntry
+            LedgerObject::RevRegDelta(rev_reg_delta) => {
+                let mut from: Option<i64> = None;
+                if did.query.contains_key(&QueryParameter::From) {
+                    from = did
+                        .query
+                        .get(&QueryParameter::From)
+                        .and_then(|d| OffsetDateTime::parse(d, &Rfc3339).ok())
+                        .and_then(|d| Some(d.unix_timestamp()));
+                }
+
+                let to = parse_or_now(did.query.get(&QueryParameter::To))?;
+
+                builder.build_get_revoc_reg_delta_request(
+                    None,
+                    &RevocationRegistryId::from_str(
+                        format!(
+                            "{}:4:{}:3:CL:{}:{}:CL_ACCUM:{}",
+                            &did.id,
+                            &did.id,
+                            rev_reg_delta.schema_seq_no,
+                            rev_reg_delta.claim_def_name,
+                            rev_reg_delta.tag
+                        )
+                        .as_str(),
+                    )
+                    .unwrap(),
+                    from,
+                    to,
+                )
+            }
+        }
+    } else {
+        let seq_no: Option<i32> = did
+            .query
+            .get(&QueryParameter::VersionId)
+            .and_then(|v| v.parse().ok());
+        let timestamp: Option<u64> = did
+            .query
+            .get(&QueryParameter::VersionTime)
+            .and_then(|d| OffsetDateTime::parse(d, &Rfc3339).ok())
+            .and_then(|d| Some(d.unix_timestamp()))
+            .and_then(|d| Some(d as u64));
+
+        builder.build_get_nym_request(Option::None, &did.id, seq_no, timestamp)
+    };
+    request
+}
+
+pub fn handle_resolution_result(
+    namespace: &str,
+    ledger_data: &str,
+    txn_type: &str,
+) -> VdrResult<(Result, Metadata)> {
+    let data = parse_ledger_data(&ledger_data)?;
+    Ok(match txn_type {
+        constants::GET_NYM => {
+            let get_nym_result: GetNymResultV1 = serde_json::from_str(data.as_str().unwrap())
+                .map_err(|_| err_msg(VdrErrorKind::Resolver, "Could not parse NYM data"))?;
+
+            let did_document = DidDocument::new(
+                namespace,
+                &get_nym_result.dest,
+                &get_nym_result.verkey,
+                None,
+                get_nym_result.diddoc_content.map(|v| serde_json::from_str(&v).unwrap()),
+            );
+
+            let metadata = Metadata::DidDocumentMetadata(DidDocumentMetadata {
+                node_response: serde_json::from_str(&ledger_data).unwrap(),
+                object_type: String::from("NYM"),
+                self_certification_version: get_nym_result.version,
+            });
+
+            (Result::DidDocument(did_document), metadata)
+        }
+        constants::GET_CRED_DEF => (
+            Result::Content(data),
+            Metadata::ContentMetadata(ContentMetadata {
+                node_response: serde_json::from_str(&ledger_data).unwrap(),
+                object_type: String::from("CRED_DEF"),
+            }),
+        ),
+        constants::GET_SCHEMA => (
+            Result::Content(data),
+            Metadata::ContentMetadata(ContentMetadata {
+                node_response: serde_json::from_str(&ledger_data).unwrap(),
+                object_type: String::from("SCHEMA"),
+            }),
+        ),
+        constants::GET_REVOC_REG_DEF => (
+            Result::Content(data),
+            Metadata::ContentMetadata(ContentMetadata {
+                node_response: serde_json::from_str(&ledger_data).unwrap(),
+                object_type: String::from("REVOC_REG_DEF"),
+            }),
+        ),
+        constants::GET_REVOC_REG_DELTA => (
+            Result::Content(data),
+            Metadata::ContentMetadata(ContentMetadata {
+                node_response: serde_json::from_str(&ledger_data).unwrap(),
+                object_type: String::from("REVOC_REG_DELTA"),
+            }),
+        ),
+        _ => (
+            Result::Content(data),
+            Metadata::ContentMetadata(ContentMetadata {
+                node_response: serde_json::from_str(&ledger_data).unwrap(),
+                object_type: String::from("REVOC_REG_DELTA"),
+            }),
+        ),
+    })
+}
+
+pub fn parse_ledger_data(ledger_data: &str) -> VdrResult<SJsonValue> {
+    let v: SJsonValue = serde_json::from_str(&ledger_data)
+        .map_err(|_| err_msg(VdrErrorKind::Resolver, "Could not parse ledger response"))?;
+    let data: &SJsonValue = &v["result"]["data"];
+    if *data == SJsonValue::Null {
+        Err(err_msg(
+            VdrErrorKind::Resolver,
+            format!("Empty data in ledger response"),
+        ))
+    } else {
+        Ok(data.to_owned())
+    }
+}
+
+pub fn parse_or_now(datetime: Option<&String>) -> VdrResult<i64> {
+    match datetime {
+        Some(datetime) => {
+            let dt = OffsetDateTime::parse(datetime, &Rfc3339).map_err(|_| {
+                err_msg(
+                    VdrErrorKind::Resolver,
+                    format!("Could not parse datetime {}", datetime),
+                )
+            })?;
+            Ok(dt.unix_timestamp())
+        }
+        None => Ok(OffsetDateTime::now_utc().unix_timestamp()),
+    }
+}
+
+pub async fn handle_request<T: Pool>(pool: &T, request: &PreparedRequest) -> VdrResult<String> {
+    let (result, _timing) = request_transaction(pool, &request).await?;
+    match result {
+        RequestResult::Reply(data) => Ok(data),
+        RequestResult::Failed(error) => Err(error),
+    }
+}
+
+pub async fn request_transaction<T: Pool>(
+    pool: &T,
+    request: &PreparedRequest,
+) -> VdrResult<(RequestResult<String>, Option<TimingResult>)> {
+    perform_ledger_request(pool, &request).await
+}
+
+/// Fetch legacy service endpoint using ATTRIB tx
+pub async fn fetch_legacy_endpoint<T: Pool>(pool: &T, did: &DidValue) -> VdrResult<Endpoint> {
+    let builder = pool.get_request_builder();
+    let request = builder.build_get_attrib_request(
+        None,
+        did,
+        Some(String::from(LEGACY_INDY_SERVICE)),
+        None,
+        None,
+    )?;
+    let ledger_data = handle_request(pool, &request).await?;
+    let endpoint_data = parse_ledger_data(&ledger_data)?;
+    let endpoint_data: Endpoint = serde_json::from_str(endpoint_data.as_str().unwrap())
+        .map_err(|_| err_msg(VdrErrorKind::Resolver, "Could not parse endpoint data"))?;
+    Ok(endpoint_data)
+}
+
+pub fn fetch_legacy_endpoint_with_runner(
+    runner: &PoolRunner,
+    did: &DidValue,
+    callback: Callback<VdrResult<Endpoint>>,
+) -> VdrResult<()> {
+    let builder = RequestBuilder::default();
+    let request = builder.build_get_attrib_request(
+        None,
+        did,
+        Some(String::from(LEGACY_INDY_SERVICE)),
+        None,
+        None,
+    )?;
+    runner.send_request(
+        request,
+        Box::new(move |result| match result {
+            Ok((res, _)) => match res {
+                RequestResult::Reply(reply_data) => {
+                    let endpoint_data = parse_ledger_data(&reply_data).unwrap();
+                    let endpoint_data: Endpoint =
+                        serde_json::from_str(endpoint_data.as_str().unwrap()).unwrap();
+                    callback(Ok(endpoint_data));
+                }
+                RequestResult::Failed(err) => callback(Err(err)),
+            },
+            Err(err) => callback(Err(err)),
+        }),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+
+    use urlencoding::encode;
+
+    use time::format_description::well_known::Rfc3339;
+    use time::OffsetDateTime;
+
+    use super::*;
+    use rstest::*;
+
+    use crate::pool::ProtocolVersion;
+
+    #[fixture]
+    fn request_builder() -> RequestBuilder {
+        RequestBuilder::new(ProtocolVersion::Node1_4)
+    }
+
+    #[rstest]
+    fn build_get_revoc_reg_request_from_version_time(request_builder: RequestBuilder) {
+        let datetime_as_str = "2020-12-20T19:17:47Z";
+        let did_url_as_str = format!("did:indy:idunion:Dk1fRRTtNazyMuK2cr64wp/anoncreds/v0/REV_REG_ENTRY/104/revocable/a4e25e54?versionTime={}",datetime_as_str);
+        let did_url = DidUrl::from_str(&did_url_as_str).unwrap();
+        let request = build_request(&did_url, &request_builder).unwrap();
+        let timestamp = (*(request.req_json).get("operation").unwrap())
+            .get("timestamp")
+            .unwrap()
+            .as_u64()
+            .unwrap() as i64;
+        assert_eq!(constants::GET_REVOC_REG, request.txn_type);
+
+        assert_eq!(
+            OffsetDateTime::parse(datetime_as_str, &Rfc3339)
+                .unwrap()
+                .unix_timestamp(),
+            timestamp
+        );
+    }
+
+    #[rstest]
+    fn build_get_revoc_reg_without_version_time(request_builder: RequestBuilder) {
+        let now = OffsetDateTime::now_utc().unix_timestamp();
+
+        let did_url_as_str = "did:indy:idunion:Dk1fRRTtNazyMuK2cr64wp/anoncreds/v0/REV_REG_ENTRY/104/revocable/a4e25e54";
+        let did_url = DidUrl::from_str(did_url_as_str).unwrap();
+        let request = build_request(&did_url, &request_builder).unwrap();
+        let timestamp = (*(request.req_json).get("operation").unwrap())
+            .get("timestamp")
+            .unwrap()
+            .as_u64()
+            .unwrap() as i64;
+
+        assert_eq!(constants::GET_REVOC_REG, request.txn_type);
+        assert!(timestamp >= now);
+    }
+
+    #[rstest]
+    fn build_get_revoc_reg_request_fails_with_unparsable_version_time(
+        request_builder: RequestBuilder,
+    ) {
+        let datetime_as_str = "20201220T19:17:47Z";
+        let did_url_as_str = format!("did:indy:idunion:Dk1fRRTtNazyMuK2cr64wp/anoncreds/v0/REV_REG_ENTRY/104/revocable/a4e25e54?versionTime={}",datetime_as_str);
+        let did_url = DidUrl::from_str(&did_url_as_str).unwrap();
+        let _err = build_request(&did_url, &request_builder).unwrap_err();
+    }
+
+    #[rstest]
+    fn build_get_revoc_reg_delta_request_with_from_to(request_builder: RequestBuilder) {
+        let from_as_str = "2019-12-20T19:17:47Z";
+        let to_as_str = "2020-12-20T19:17:47Z";
+        let did_url_as_str = format!("did:indy:idunion:Dk1fRRTtNazyMuK2cr64wp/anoncreds/v0/REV_REG_ENTRY/104/revocable/a4e25e54?from={}&to={}",from_as_str, to_as_str);
+        let did_url = DidUrl::from_str(&did_url_as_str).unwrap();
+        let request = build_request(&did_url, &request_builder).unwrap();
+        assert_eq!(request.txn_type, constants::GET_REVOC_REG_DELTA);
+    }
+
+    #[rstest]
+    fn build_get_revoc_reg_delta_request_with_from_only(request_builder: RequestBuilder) {
+        let now = OffsetDateTime::now_utc().unix_timestamp();
+        let from_as_str = "2019-12-20T19:17:47Z";
+        let did_url_as_str = format!("did:indy:idunion:Dk1fRRTtNazyMuK2cr64wp/anoncreds/v0/REV_REG_ENTRY/104/revocable/a4e25e54?from={}",from_as_str);
+        let did_url = DidUrl::from_str(&did_url_as_str).unwrap();
+        let request = build_request(&did_url, &request_builder).unwrap();
+
+        let to = (*(request.req_json).get("operation").unwrap())
+            .get("to")
+            .unwrap()
+            .as_u64()
+            .unwrap() as i64;
+        assert_eq!(request.txn_type, constants::GET_REVOC_REG_DELTA);
+        assert!(to >= now)
+    }
+
+    #[rstest]
+    fn build_get_revoc_reg_delta_request_without_parameter(request_builder: RequestBuilder) {
+        let now = OffsetDateTime::now_utc().unix_timestamp();
+        let did_url_as_str = "did:indy:idunion:Dk1fRRTtNazyMuK2cr64wp/anoncreds/v0/REV_REG_DELTA/104/revocable/a4e25e54";
+        let did_url = DidUrl::from_str(did_url_as_str).unwrap();
+        let request = build_request(&did_url, &request_builder).unwrap();
+
+        let to = (*(request.req_json).get("operation").unwrap())
+            .get("to")
+            .unwrap()
+            .as_u64()
+            .unwrap() as i64;
+
+        let from = (*(request.req_json).get("operation").unwrap()).get("from");
+        assert_eq!(request.txn_type, constants::GET_REVOC_REG_DELTA);
+        assert!(from.is_none());
+        assert!(to >= now);
+    }
+
+    #[rstest]
+    fn build_get_schema_request_with_whitespace(request_builder: RequestBuilder) {
+        let name = "My Schema";
+        let encoded_schema_name = encode(name).to_string();
+        let did_url_string = format!(
+            "did:indy:idunion:Dk1fRRTtNazyMuK2cr64wp/anoncreds/v0/SCHEMA/{}/1.0",
+            encoded_schema_name
+        );
+
+        let did_url = DidUrl::from_str(did_url_string.as_str()).unwrap();
+        let request = build_request(&did_url, &request_builder).unwrap();
+        let schema_name = (*(request.req_json).get("operation").unwrap())
+            .get("data")
+            .and_then(|v| v.get("name"))
+            .and_then(|v| v.as_str())
+            .unwrap();
+        assert_eq!(schema_name, name);
+    }
+}

--- a/libindy_vdr/src/resolver/utils.rs
+++ b/libindy_vdr/src/resolver/utils.rs
@@ -169,7 +169,9 @@ pub fn handle_resolution_result(
                 &get_nym_result.dest,
                 &get_nym_result.verkey,
                 None,
-                get_nym_result.diddoc_content.map(|v| serde_json::from_str(&v).unwrap()),
+                get_nym_result
+                    .diddoc_content
+                    .map(|v| serde_json::from_str(&v).unwrap()),
             );
 
             let metadata = Metadata::DidDocumentMetadata(DidDocumentMetadata {

--- a/libindy_vdr/tests/resolver.rs
+++ b/libindy_vdr/tests/resolver.rs
@@ -1,0 +1,99 @@
+#[macro_use]
+mod utils;
+
+inject_dependencies!();
+
+#[test]
+fn empty() {
+    // Empty test to run module
+}
+
+#[cfg(test)]
+// #[cfg(feature = "local_nodes_pool_did_indy")]
+mod send_resolver {
+    use futures_executor::block_on;
+    use indy_vdr::resolver::PoolResolver as Resolver;
+
+    use super::*;
+
+    use crate::utils::crypto::Identity;
+    use crate::utils::fixtures::*;
+    use crate::utils::helpers;
+    use crate::utils::pool::TestPool;
+
+    #[rstest]
+    fn test_pool_resolve_did(
+        pool: TestPool,
+        trustee: Identity,
+        identity: Identity,
+        diddoc_content: serde_json::Value,
+    ) {
+        // Send NYM
+        let mut nym_request = pool
+            .request_builder()
+            .build_nym_request(
+                &trustee.did,
+                &identity.did,
+                Some(identity.verkey.to_string()),
+                None,
+                None,
+                Some(&diddoc_content),
+                None,
+            )
+            .unwrap();
+
+        let _nym_response =
+            helpers::sign_and_send_request(&trustee, &pool, &mut nym_request).unwrap();
+
+        // Resolve DID
+        let resolver = Resolver::new(pool.pool);
+        let qualified_did = format!("did:indy:test:{}", &identity.did);
+        let result = block_on(resolver.resolve(&qualified_did)).unwrap();
+
+        let v: serde_json::Value = serde_json::from_str(result.as_str()).unwrap();
+
+        let diddoc = &v["didDocument"];
+        let metadata = &v["didDocumentMetadata"];
+
+        assert_eq!("NYM", metadata["objectType"]);
+        assert_ne!(&serde_json::Value::Null, diddoc)
+    }
+
+    // #[rstest]
+    // fn test_pool_resolve_did_with_version_id(
+    //     pool: TestPool,
+    //     trustee: Identity,
+    //     identity: Identity
+    // ) {
+    //     // Send NYM
+    //     let mut nym_request = pool
+    //         .request_builder()
+    //         .build_nym_request(
+    //             &trustee.did,
+    //             &identity.did,
+    //             Some(identity.verkey.to_string()),
+    //             None,
+    //             None,
+    //             None,
+    //             None,
+    //         )
+    //         .unwrap();
+
+    //     let _nym_response =
+    //         helpers::sign_and_send_request(&trustee, &pool, &mut nym_request).unwrap();
+
+    //     // Resolve DID
+    //     let resolver = Resolver::new(pool.pool);
+    //     let qualified_did = format!("did:indy:test:{}", &identity.did);
+    //     let did_url = format!("{}?versionId=1", qualified_did);
+    //     let result = block_on(resolver.resolve(&did_url)).unwrap();
+
+    //     let v: serde_json::Value = serde_json::from_str(result.as_str()).unwrap();
+
+    //     let diddoc = &v["didDocument"];
+    //     let metadata = &v["didDocumentMetadata"];
+
+    //     assert_eq!("NYM", metadata["objectType"]);
+    //     assert_ne!(&serde_json::Value::Null, diddoc);
+    // }
+}

--- a/libindy_vdr/tests/utils/pool.rs
+++ b/libindy_vdr/tests/utils/pool.rs
@@ -9,7 +9,7 @@ use indy_vdr::pool::{
 use futures_executor::block_on;
 
 pub struct TestPool {
-    pool: SharedPool,
+    pub pool: SharedPool,
 }
 
 impl TestPool {

--- a/wrappers/golang/vdr/indy_vdr.go
+++ b/wrappers/golang/vdr/indy_vdr.go
@@ -127,11 +127,13 @@ func (r *Client) Submit(request []byte) (*ReadReply, error) {
 }
 
 //GetNym fetches the NYM transaction associated with a DID
+//FIXME: Expose optional seq_no and timestamp to get specific NYM versions
+// on did:indy compliant ledgers
 func (r *Client) GetNym(did string) (*ReadReply, error) {
 	var nymreq C.int64_t
 	var none *C.char
-	var none32 C.int32_t = -1
-	var none64 C.int64_t = -1
+	var none32 C.int32_t = -1 // seq_no
+	var none64 C.int64_t = -1 // timestamp
 	cdid := C.CString(did)
 	result := C.indy_vdr_build_get_nym_request(none, cdid, none32, none64, &nymreq)
 	C.free(unsafe.Pointer(cdid))

--- a/wrappers/golang/vdr/writes.go
+++ b/wrappers/golang/vdr/writes.go
@@ -4,6 +4,7 @@ import (
 	"github.com/pkg/errors"
 )
 
+// FIXME: Expose optional diddoc_content and version field on did:indy compliant ledgers
 func (r *Client) CreateNym(did, verkey, role, from string, signer Signer) error {
 	nymRequest := NewNym(did, verkey, from, role)
 

--- a/wrappers/python/.gitignore
+++ b/wrappers/python/.gitignore
@@ -1,5 +1,6 @@
 build
 dist
+github
 .pytest_cache
 __pycache__
 *.dll

--- a/wrappers/python/indy_vdr/bindings.py
+++ b/wrappers/python/indy_vdr/bindings.py
@@ -261,7 +261,7 @@ def resolve(pool_handle: PoolHandle, did: str) -> asyncio.Future:
 
 
 def dereference(pool_handle: PoolHandle, did_url: str) -> asyncio.Future:
-    """Dereference a DID Urk to retrieve a ledger object."""
+    """Dereference a DID Url to retrieve a ledger object."""
     return do_call_async(
         "indy_vdr_dereference",
         pool_handle,

--- a/wrappers/python/indy_vdr/ledger.py
+++ b/wrappers/python/indy_vdr/ledger.py
@@ -489,7 +489,7 @@ def build_nym_request(
     alias: str = None,
     role: str = None,
     diddoc_content: str = None,
-    version: Optional[int] = None,
+    version: int = None,
 ) -> Request:
     """
     Builds a NYM request to create new DID on the ledger.
@@ -521,7 +521,7 @@ def build_nym_request(
     alias_p = encode_str(alias) if alias else None
     role_p = encode_str(role) if role else None
     diddoc_content_p = encode_str(diddoc_content) if diddoc_content else None
-    version = c_int32(version if version is not None else -1)
+    version_c = c_int32(version if version is not None else -1)
     do_call(
         "indy_vdr_build_nym_request",
         did_p,
@@ -530,7 +530,7 @@ def build_nym_request(
         alias_p,
         role_p,
         diddoc_content_p,
-        version,
+        version_c,
         byref(handle),
     )
     return Request(handle)


### PR DESCRIPTION
- Indy Vdr Proxy with multiple ledger support and DID Resolution API (based on Indy Vdr's `PoolResolver`)
- I've included a dockerfile for a node-pool based on Indicio's indy-node branch with the did:indy implementation  (HT @dbluhm). This pool is now used for the integration tests in indy-vdr's did-indy branch.

## Usage

The `indy-vdr-proxy` executable can be used to provide a simple REST API for interacting with one or more Indy ledgers. Command line options can be inspected by running `indy-vdr-proxy --help`.

To start the proxy server for a single ledger use the following command:
`indy-vdr-proxy -p <PORT> (-g <OPTIONAL_PATH_TO_GENESIS_FILE>)`

To start the proxy server with the standard configuration of indy ledgers use the following command:
`indy-vdr-proxy -p <PORT> --multiple-ledgers`
This will get the ledger configuration from `https://github.com/IDunion/indy-did-networks`

A custom ledger configuration can be provided either by specificing a Github repo or a local folder:
`indy-vdr-proxy -p <PORT> --multiple-ledgers -g <GITHUB_URL or PATH_TO_FOLDER>`
The structure needs to be as follows `<NAMESPACE>/OPTIONAL<SUB_NAMESPACE>/pool_transactions_genesis.json`, e.g. `/sovrin/staging/pool_transactions_genesis.json`

Responses can be formatted in either HTML or JSON formats. HTML formatting is selected when the `text/html` content type is requested according to the Accept header (as sent by web browsers) or the request query string is set to `?html`. JSON formatting is selected otherwise, and may be explitly selected by using the query string `?raw`. For most ledger requests, JSON responses include information regarding which nodes were contacted is returned in the `X-Requests` header.

Sending prepared requests to the ledger is performed by delivering a POST request to the `{LEDGER}/submit` endpoint, where the body of the request is the JSON-formatted payload. Additional endpoints are provided as shortcuts for ledger read transactions:

- `{LEDGER}/` The root path shows basic status information about the server and the ledger pool
- `{LEDGER}/genesis` Return the current set of genesis transactions
- `{LEDGER}/taa` Fetch the current ledger Transaction Author Agreement
- `{LEDGER}/aml` Fetch the current ledger Acceptance Methods List (for the TAA)
- `{LEDGER}/nym/{DID}` Fetch the NYM transaction associated with an unqualified DID
- `{LEDGER}/attrib/{DID}/endpoint` Fetch the registered endpoint for an unqualified DID
- `{LEDGER}/schema/{SCHEMA_ID}` Fetch a schema by its identifier
- `{LEDGER}/cred_def/{CRED_DEF_ID}` Fetch a credential definition by its identifier
- `{LEDGER}/rev_reg/{REV_REG_ID}` Fetch a revocation registry by its identifier
- `{LEDGER}/rev_reg_def/{REV_REG_ID}` Fetch a revocation registry definition by its registry identifier
- `{LEDGER}/rev_reg_delta/{REV_REG_ID}` Fetch a revocation registry delta by its registry identifier
- `{LEDGER}/auth` Fetch all AUTH rules for the ledger
- `{LEDGER}/auth/{TXN_TYPE}/{ADD|EDIT}` Fetch the AUTH rule for a specific transaction type and action
- `{LEDGER}/txn/{SUBLEDGER}/{SEQ_NO}` Fetch a specific transaction by subledger identifier (0-2, or one of `pool`, `domain`, or `config`) and sequence number.

If the proxy server is used with a single ledger, the `{LEDGER}` part of the path must be omitted.

### DID:Indy Resolver

Indy VDR contains a DID Resolver to resolve DIDs and dereference DID Urls to ledger objects from configured ledgers according to the [did:indy specification](https://hyperledger.github.io/indy-did-method/).

`GET /1.0/identifiers/{DID or DID_URL}`


