### PR TITLE
Correctly use the networks folder of the repository

### DIFF
--- a/wrappers/python/demo/test.py
+++ b/wrappers/python/demo/test.py
@@ -131,12 +131,12 @@ async def basic_test(transactions_path):
 
     resolver = Resolver(autopilot=True)
 
-    log("Resolve DID did:indy:idunion:APs6Xd2GH8FNwCaXDw6Qm2")
-    doc = await resolver.resolve("did:indy:idunion:Fhbr2wQrJeB1UcZeFKpG5F")
+    log("Resolve DID did:indy:idunion:test:APs6Xd2GH8FNwCaXDw6Qm2")
+    doc = await resolver.resolve("did:indy:idunion:test:Fhbr2wQrJeB1UcZeFKpG5F")
     log(json.dumps(doc, indent=2))
 
     try:
-        doc = await resolver.resolve("did:indy:idunion:APs6Xd2GH8FNwCaXDw6Qm2")
+        doc = await resolver.resolve("did:indy:idunion:test:APs6Xd2GH8FNwCaXDw6Qm2")
     except VdrError as err:
         print(err)
 

--- a/wrappers/python/indy_vdr/utils.py
+++ b/wrappers/python/indy_vdr/utils.py
@@ -73,7 +73,7 @@ def get_genesis_txns_from_did_indy_repo_by_name(
         main = next(parts, None)
         sub = next(parts, None)
 
-        genesis_file_url = f"{INDY_NETWORKS_GITHUB_RAW_BASE}/{name}/{genesis_filename}"
+        genesis_file_url = f"{INDY_NETWORKS_GITHUB_RAW_BASE}/networks/{name}/{genesis_filename}"
         target_local_path = f"{base_dir}/{name}/{genesis_filename}"
         try:
             urllib.request.urlretrieve(genesis_file_url, target_local_path)


### PR DESCRIPTION
Correctly use the networks folder as described in the spec: https://hyperledger.github.io/indy-did-method/#dynamic-using-github 
This should fix the failing test for the python wrapper