### PR TITLE
updated ZMQ to the latest version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,7 +50,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: build
-          args: --manifest-path libindy_vdr/Cargo.toml --features zmq_vendored
+          args: --manifest-path libindy_vdr/Cargo.toml
 
   test-suite:
     name: Run Test Suite
@@ -111,7 +111,6 @@ jobs:
       - name: Build library
         env:
           BUILD_TARGET: ${{ matrix.target }}
-          BUILD_FEATURES: zmq_vendored
         run: sh ./build.sh
 
       - name: Upload library artifacts
@@ -154,7 +153,6 @@ jobs:
         env:
           BUILD_TARGET: ${{ matrix.target }}
           BUILD_TOOLCHAIN: ${{ matrix.toolchain }}
-          BUILD_FEATURES: zmq_vendored
         run: sh ./build.sh
 
       - name: Upload library artifacts

--- a/indy-vdr-proxy/Cargo.toml
+++ b/indy-vdr-proxy/Cargo.toml
@@ -8,8 +8,7 @@ license = "Apache-2.0"
 
 [features]
 fetch = ["hyper-tls", "hyper/client"]
-zmq_vendored = ["indy-vdr/zmq_vendored"]
-default = ["fetch", "zmq_vendored"]
+default = ["fetch"]
 
 [dependencies]
 clap = "3.1"

--- a/libindy_vdr/Cargo.toml
+++ b/libindy_vdr/Cargo.toml
@@ -18,10 +18,9 @@ crate-type = ["staticlib", "rlib", "cdylib"]
 [features]
 ffi = ["ffi-support", "logger"]
 logger = ["env_logger", "log"]
-zmq_vendored = ["zmq/vendored"]
 local_nodes_pool = []
 rich_schema = ["indy-data-types/rich_schema"]
-default = ["ffi", "log", "zmq_vendored"]
+default = ["ffi", "log"]
 
 [dependencies]
 env_logger = { version = "0.9", optional = true }
@@ -44,7 +43,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 sha3 = "0.10"
 thiserror = "1.0"
-zmq = "0.9"
+zmq = "0.10"
 
 [dependencies.ursa]
 version = "0.3.5"

--- a/libindy_vdr/Cargo.toml
+++ b/libindy_vdr/Cargo.toml
@@ -43,7 +43,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 sha3 = "0.10"
 thiserror = "1.0"
-zmq = "0.10"
+zmq = { package = "zmq2", git = "https://github.com/erickt/rust-zmq.git", rev = "5821ee121c30311d961e18b9ff7017603c600548" }
 
 [dependencies.ursa]
 version = "0.3.5"


### PR DESCRIPTION
- No more zmq vendored feature
- makes cross-compilation a lot easier as `libzmq3-dev` is not required anymore (this is required for the upcoming Android pipeline)
- Tests still pass 
- [changelog](https://github.com/erickt/rust-zmq/releases/tag/v0.10.0) 