### PR TITLE
Update build actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,16 +30,13 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Install Rust toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
+        uses: dtolnay/rust-toolchain@stable
 
       - name: Cache cargo resources
-        uses: Swatinem/rust-cache@v1
+        uses: Swatinem/rust-cache@v2
 
       - name: Cargo check
         uses: actions-rs/cargo@v1
@@ -64,16 +61,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Install Rust toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
+        uses: dtolnay/rust-toolchain@stable
 
       - name: Cache cargo resources
-        uses: Swatinem/rust-cache@v1
+        uses: Swatinem/rust-cache@v2
 
       - name: Run node pool
         run: |
@@ -87,117 +81,71 @@ jobs:
           command: test
           args: --manifest-path libindy_vdr/Cargo.toml --features local_nodes_pool
 
-  build-manylinux:
-    name: Build Library (Manylinux)
-    needs: [check]
-
-    strategy:
-      matrix:
-        include:
-          - os: ubuntu-latest
-            lib: libindy_vdr.so
-            container: andrewwhitehead/manylinux2014-base
-            platform: linux
-
-    container: ${{ matrix.container }}
-    runs-on: ${{ matrix.os }}
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-
-      - name: Install Rust toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-
-      - name: Cache cargo resources
-        uses: Swatinem/rust-cache@v1
-
-      - name: Build library
-        env:
-          BUILD_TARGET: ${{ matrix.target }}
-          BUILD_FEATURES: zmq_vendored
-        run: sh ./build.sh
-
-      - name: Upload library artifacts
-        uses: actions/upload-artifact@v2
-        with:
-          name: library-${{ runner.os }}
-          path: target/release/${{ matrix.lib }}
-
-      - name: Create library artifacts directory
-        if: |
-          github.event_name == 'release' || 
-          (github.event_name == 'workflow_dispatch' && github.event.inputs.publish-binaries == 'true')
-        run: |
-          mkdir release-artifacts
-          cp target/release/${{ matrix.lib }} release-artifacts/
-
-      - uses: a7ul/tar-action@v1.1.2
-        if: |
-          github.event_name == 'release' || 
-          (github.event_name == 'workflow_dispatch' && github.event.inputs.publish-binaries == 'true')
-        with:
-          command: c
-          cwd: release-artifacts
-          files: .
-          outPath: "library-${{ matrix.platform }}.tar.gz"
-
-      - name: Add library artifacts to release
-        if: |
-          github.event_name == 'release' || 
-          (github.event_name == 'workflow_dispatch' && github.event.inputs.publish-binaries == 'true')
-        uses: svenstaro/upload-release-action@v2
-        with:
-          file: library-${{ matrix.platform }}.tar.gz
-          asset_name: "library-${{ matrix.platform }}.tar.gz"
-
   build-release:
-    name: Build Library (MacOS/Win)
+    name: Build Library
     needs: [check]
 
     strategy:
       matrix:
         include:
-          - os: macos-11
+          - arch: linux-aarch64
+            os: ubuntu-latest
+            lib: libindy_vdr.so
+            target: aarch64-unknown-linux-gnu
+            use_cross: true
+          - arch: linux-x86_64
+            os: ubuntu-latest
+            lib: libindy_vdr.so
+            target: x86_64-unknown-linux-gnu
+            # using cross here to build against an older glibc for compatibility
+            use_cross: true
+          - arch: darwin-universal
+            os: macos-11
             lib: libindy_vdr.dylib
             target: apple-darwin
-            toolchain: beta #  beta required for aarch64-apple-darwin target
-            platform: darwin
-          - os: windows-latest
+            # beta or nightly required for aarch64-apple-darwin target
+            toolchain: beta
+          - arch: windows-x86_64
+            os: windows-latest
             lib: indy_vdr.dll
-            toolchain: stable
-            platform: windows
+            target: x86_64-pc-windows-msvc
 
     runs-on: ${{ matrix.os }}
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Install Rust toolchain
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@master
         with:
-          profile: minimal
-          toolchain: ${{ matrix.toolchain }}
+          toolchain: ${{ matrix.toolchain || 'stable' }}
 
       - name: Cache cargo resources
-        uses: Swatinem/rust-cache@v1
+        uses: Swatinem/rust-cache@v2
 
-      - name: Build library
+      - if: "!matrix.use_cross"
+        name: Build library
         env:
           BUILD_TARGET: ${{ matrix.target }}
-          BUILD_TOOLCHAIN: ${{ matrix.toolchain }}
+          BUILD_TOOLCHAIN: ${{ matrix.toolchain || 'stable' }}
           BUILD_FEATURES: zmq_vendored
-        run: sh ./build.sh
+        shell: sh
+        run: ./build.sh
+
+      - if: matrix.use_cross
+        name: Build library (cross)
+        uses: actions-rs/cargo@v1
+        with:
+          use-cross: true
+          command: build
+          args: --lib --release --target ${{ matrix.target }} --features zmq_vendored
 
       - name: Upload library artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
-          name: library-${{ runner.os }}
-          path: target/release/${{ matrix.lib }}
+          name: library-${{ matrix.arch }}
+          path: target/${{ matrix.target }}/release/${{ matrix.lib }}
 
       - name: Create library artifacts directory
         if: |
@@ -205,7 +153,7 @@ jobs:
           (github.event_name == 'workflow_dispatch' && github.event.inputs.publish-binaries == 'true')
         run: |
           mkdir release-artifacts
-          cp target/release/${{ matrix.lib }} release-artifacts/
+          cp target/${{ matrix.target }}/release/${{ matrix.lib }} release-artifacts/
 
       - uses: a7ul/tar-action@v1.1.2
         if: |
@@ -215,7 +163,7 @@ jobs:
           command: c
           cwd: release-artifacts
           files: .
-          outPath: "library-${{ matrix.platform }}.tar.gz"
+          outPath: "library-${{ matrix.arch }}.tar.gz"
 
       - name: Add library artifacts to release
         if: |
@@ -223,17 +171,17 @@ jobs:
           (github.event_name == 'workflow_dispatch' && github.event.inputs.publish-binaries == 'true')
         uses: svenstaro/upload-release-action@v2
         with:
-          file: library-${{ matrix.platform }}.tar.gz
-          asset_name: "library-${{ matrix.platform }}.tar.gz"
+          file: library-${{ matrix.arch }}.tar.gz
+          asset_name: "library-${{ matrix.arch }}.tar.gz"
 
   build-golang:
     name: Build and Test Go wrapper
-    needs: [build-manylinux]
+    needs: [build-release]
     runs-on: ubuntu-latest
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: "Use Golang 1.16.x+"
         uses: actions/setup-go@v2
@@ -241,9 +189,9 @@ jobs:
           go-version: "^1.16.0"
 
       - name: Fetch library artifacts
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
-          name: library-${{ runner.os }}
+          name: library-linux-x86_64
 
       - name: Build and test wrapper
         run: |
@@ -253,7 +201,7 @@ jobs:
 
   build-javascript:
     name: Build and Test JavaScript wrapper
-    needs: [build-manylinux, build-release]
+    needs: [build-release]
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -261,7 +209,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Set up Node.JS 16.x
         uses: actions/setup-node@v3
@@ -269,9 +217,9 @@ jobs:
           node-version: 16.x
 
       - name: Fetch library artifacts
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
-          name: library-${{ runner.os }}
+          name: library-linux-x86_64
 
       - name: Install dependencies
         run: yarn install
@@ -313,74 +261,36 @@ jobs:
           (github.event_name == 'workflow_dispatch' && github.event.inputs.publish-wrappers == 'true')
         run: npx lerna publish from-package --no-push --no-private --yes --no-git-tag-version
 
-  # build-nodejs:
-  #   name: Build and Test NodeJS wrapper
-  #   needs: [build-manylinux]
-  #   runs-on: ubuntu-latest
-
-  #   steps:
-  #     - name: Checkout
-  #       uses: actions/checkout@v2
-
-  #     - name: Use Node.js 12.x
-  #       uses: actions/setup-node@v1
-  #       with:
-  #         node-version: 12.x
-
-  #     - name: Fetch library artifacts
-  #       uses: actions/download-artifact@v2
-  #       with:
-  #         name: library-${{ runner.os }}
-
-  #     - name: Build and test wrapper
-  #       run: |
-  #         sudo cp libindy_vdr.so /usr/lib/
-  #         cd wrappers/nodejs
-  #         npm install
-  #         npm run compile
-  #         npm run test:unit
-
-  #     - name: Run NodeJS integration tests against Sovrin Buildernet
-  #       run: |
-  #         INDY_NETWORK=SOVRIN_BUILDER_NET npm run test:integration
-  #       working-directory: wrappers/nodejs
-
-  #     - if: |
-  #         (github.event_name == 'release' ||
-  #           (github.event_name == 'workflow_dispatch' &&
-  #            github.event.inputs.publish == 'true'))
-  #       name: Publish npm package
-  #       env:
-  #         NODE_AUTH_TOKEN: ${{secrets.npm_token}}
-  #       run: |
-  #         npm ci
-  #         npm publish
-  #       working-directory: wrappers/nodejs
-
   build-py:
     name: Build and Test Python Wrapper
-    needs: [build-manylinux, build-release]
+    needs: [build-release]
 
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-11, windows-latest]
-        python-version: [3.6]
+        arch: [linux-aarch64, linux-x86_64, darwin-universal, windows-x86_64]
+        python-version: ["3.8"]
         include:
           - os: ubuntu-latest
+            arch: linux-aarch64
+            plat-name: manylinux2014_aarch64
+          - os: ubuntu-latest
+            arch: linux-x86_64
             plat-name: manylinux2014_x86_64
           - os: macos-11
+            arch: darwin-universal
             plat-name: macosx_10_9_universal2 # macosx_10_9_x86_64
           - os: windows-latest
+            arch: windows-x86_64
             plat-name: win_amd64
 
     runs-on: ${{ matrix.os }}
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -390,15 +300,23 @@ jobs:
           pip install setuptools wheel twine auditwheel
 
       - name: Fetch library artifacts
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
-          name: library-${{ runner.os }}
+          name: library-${{ matrix.arch }}
           path: wrappers/python/indy_vdr/
 
-      - name: Build and test python package
+      - name: Build python package
         shell: sh
         run: |
           python setup.py bdist_wheel --python-tag=py3 --plat-name=${{ matrix.plat-name }}
+        working-directory: wrappers/python
+
+      - name: Test python package
+        # FIXME cross platform test the python package
+        # maybe use the cross docker image?
+        if: "matrix.arch != 'linux-aarch64'"
+        shell: sh
+        run: |
           pip install dist/*
           python -m demo.test
         working-directory: wrappers/python
@@ -408,9 +326,9 @@ jobs:
         run: auditwheel show wrappers/python/dist/*
 
       - name: Upload python package
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
-          name: python-${{ runner.os }}
+          name: python-${{ matrix.arch }}
           path: wrappers/python/dist/*
 
       - if: |

--- a/Cross.toml
+++ b/Cross.toml
@@ -1,0 +1,5 @@
+[target.aarch64-unknown-linux-gnu]
+image = "ghcr.io/cross-rs/aarch64-unknown-linux-gnu:main"
+
+[target.x86_64-unknown-linux-gnu]
+image = "ghcr.io/cross-rs/x86_64-unknown-linux-gnu:main"

--- a/build.sh
+++ b/build.sh
@@ -80,10 +80,11 @@ if [ "$TARGET" = "apple-darwin" ]; then
 		TARGET_LIBS="./target/$target/release/lib${LIB_NAME}.dylib $TARGET_LIBS"
 	done
 
-	mkdir -p ./target/release
-	OUTPUT="./target/release/lib${LIB_NAME}.dylib"
+	mkdir -p "./target/${TARGET}/release" ./target/release
+	OUTPUT="./target/${TARGET}/release/lib${LIB_NAME}.dylib"
 	echo "Combining targets into universal library"
 	lipo -create -output $OUTPUT $TARGET_LIBS
+	cp $OUTPUT ./target/release/
 else
 	# Build normal target
 	echo "Building $PROJECT for toolchain '$BUILD_TOOLCHAIN'.."


### PR DESCRIPTION
- Update to node16-compatible versions of actions
- Use cargo-cross to build linux binaries
- Add linux/arm64 build
- Use Python 3.8 over 3.6 for testing (3.6 is no longer easily available)