### PR TITLE
build(javascript): fix some small release issues

### DIFF
--- a/wrappers/javascript/indy-vdr-nodejs/package.json
+++ b/wrappers/javascript/indy-vdr-nodejs/package.json
@@ -53,7 +53,7 @@
   "binary": {
     "module_name": "indy_vdr",
     "module_path": "native",
-    "remote_path": "v0.4.0",
+    "remote_path": "v0.4.0-dev.1",
     "host": "https://github.com/hyperledger/indy-vdr/releases/download/",
     "package_name": "library-{platform}.tar.gz"
   }

--- a/wrappers/javascript/indy-vdr-react-native/package.json
+++ b/wrappers/javascript/indy-vdr-react-native/package.json
@@ -1,7 +1,6 @@
 {
   "name": "indy-vdr-react-native",
   "version": "0.1.0-dev.1",
-  "private": true,
   "license": "Apache-2.0",
   "description": "React Native wrapper for Indy Vdr",
   "source": "src/index",
@@ -59,7 +58,7 @@
   "binary": {
     "module_name": "indy_vdr",
     "module_path": "native",
-    "remote_path": "v0.4.0",
+    "remote_path": "v0.4.0-dev.1",
     "host": "https://github.com/hyperledger/indy-vdr/releases/download/",
     "package_name": "library-ios-android.tar.gz"
   }


### PR DESCRIPTION
There were some small issues with the JavaScript release. The publishing of the binaries fully worked 🎉

There's one issue before we can publish again and that is that the Indy VDR Shared package is already taken on NPM: https://www.npmjs.com/package/indy-vdr-shared. It's in security hold. I've submitted a request to Github/NPM to release the package and give us ownership. That can take weeks. I suggest we don't wait weeks, but maybe until next week. Otherwise we can use `@hyperledger` prefix for the package names.
