### PR TITLE
Added rust methods to build FREEZE_LEDGER and GET_FROZEN_LEDGER_REQUESTS

### DIFF
--- a/libindy_vdr/src/ledger/constants.rs
+++ b/libindy_vdr/src/ledger/constants.rs
@@ -6,6 +6,8 @@ pub const TXN_AUTHR_AGRMT_AML: &str = "5";
 pub const GET_TXN_AUTHR_AGRMT: &str = "6";
 pub const GET_TXN_AUTHR_AGRMT_AML: &str = "7";
 pub const DISABLE_ALL_TXN_AUTHR_AGRMTS: &str = "8";
+pub const LEDGERS_FREEZE: &str = "9";
+pub const GET_FROZEN_LEDGERS: &str = "10";
 pub const ATTRIB: &str = "100";
 pub const SCHEMA: &str = "101";
 pub const CRED_DEF: &str = "102";
@@ -36,7 +38,7 @@ pub const RICH_SCHEMA_PRES_DEF: &str = "205";
 pub const GET_RICH_SCHEMA_BY_ID: &str = "300";
 pub const GET_RICH_SCHEMA_BY_METADATA: &str = "301";
 
-pub const REQUESTS: [&str; 31] = [
+pub const REQUESTS: [&str; 33] = [
     NODE,
     NYM,
     GET_TXN,
@@ -62,6 +64,8 @@ pub const REQUESTS: [&str; 31] = [
     GET_TXN_AUTHR_AGRMT,
     GET_TXN_AUTHR_AGRMT_AML,
     DISABLE_ALL_TXN_AUTHR_AGRMTS,
+    LEDGERS_FREEZE,
+    GET_FROZEN_LEDGERS,
     RICH_SCHEMA_CTX,
     RICH_SCHEMA,
     RICH_SCHEMA_ENCODING,
@@ -132,6 +136,8 @@ pub fn txn_name_to_code(txn: &str) -> Option<&str> {
         "GET_TXN_AUTHR_AGRMT" => Some(GET_TXN_AUTHR_AGRMT),
         "GET_TXN_AUTHR_AGRMT_AML" => Some(GET_TXN_AUTHR_AGRMT_AML),
         "DISABLE_ALL_TXN_AUTHR_AGRMTS" => Some(DISABLE_ALL_TXN_AUTHR_AGRMTS),
+        "LEDGERS_FREEZE" => Some(LEDGERS_FREEZE),
+        "GET_FROZEN_LEDGERS" => Some(GET_FROZEN_LEDGERS),
         val => Some(val),
     }
 }

--- a/libindy_vdr/src/ledger/request_builder.rs
+++ b/libindy_vdr/src/ledger/request_builder.rs
@@ -20,6 +20,7 @@ use super::requests::author_agreement::{
     TxnAuthorAgreementOperation, TxnAuthrAgrmtAcceptanceData,
 };
 use super::requests::cred_def::{CredDefOperation, CredentialDefinition, GetCredDefOperation};
+use super::requests::ledgers_freeze::{GetFrozenLedgersOperation, LedgersFreezeOperation};
 use super::requests::node::{NodeOperation, NodeOperationData};
 use super::requests::nym::{role_to_code, GetNymOperation, NymOperation};
 use super::requests::pool::{
@@ -44,7 +45,6 @@ use super::requests::schema::{
 use super::requests::txn::GetTxnOperation;
 use super::requests::validator_info::GetValidatorInfoOperation;
 use super::requests::{Request, RequestType};
-use super::requests::ledgers_freeze::{GetFrozenLedgersOperation, LedgersFreezeOperation};
 
 use super::constants::txn_name_to_code;
 
@@ -609,9 +609,12 @@ impl RequestBuilder {
     pub fn build_ledger_freeze_request(
         &self,
         identifier: &DidValue,
-        ledgers_ids: &[u64]
+        ledgers_ids: &[u64],
     ) -> VdrResult<PreparedRequest> {
-        self.build(LedgersFreezeOperation::new(ledgers_ids.to_vec()), Some(identifier))
+        self.build(
+            LedgersFreezeOperation::new(ledgers_ids.to_vec()),
+            Some(identifier),
+        )
     }
 
     /// Build a `GET_FROZEN_LEDGERS` transaction request

--- a/libindy_vdr/src/ledger/request_builder.rs
+++ b/libindy_vdr/src/ledger/request_builder.rs
@@ -44,6 +44,7 @@ use super::requests::schema::{
 use super::requests::txn::GetTxnOperation;
 use super::requests::validator_info::GetValidatorInfoOperation;
 use super::requests::{Request, RequestType};
+use super::requests::ledgers_freeze::{GetFrozenLedgersOperation, LedgersFreezeOperation};
 
 use super::constants::txn_name_to_code;
 
@@ -602,6 +603,23 @@ impl RequestBuilder {
             GetRichSchemaByMetadataOperation::new(get_rs_by_meta),
             Some(identifier),
         )
+    }
+
+    /// Build a `LEDGERS_FREEZE` transaction request
+    pub fn build_ledger_freeze_request(
+        &self,
+        identifier: &DidValue,
+        ledgers_ids: &[u64]
+    ) -> VdrResult<PreparedRequest> {
+        self.build(LedgersFreezeOperation::new(ledgers_ids.to_vec()), Some(identifier))
+    }
+
+    /// Build a `GET_FROZEN_LEDGERS` transaction request
+    pub fn build_get_frozen_ledgers_request(
+        &self,
+        identifier: &DidValue,
+    ) -> VdrResult<PreparedRequest> {
+        self.build(GetFrozenLedgersOperation::new(), Some(identifier))
     }
 }
 

--- a/libindy_vdr/src/ledger/requests/ledgers_freeze.rs
+++ b/libindy_vdr/src/ledger/requests/ledgers_freeze.rs
@@ -1,0 +1,44 @@
+use super::constants::{LEDGERS_FREEZE, GET_FROZEN_LEDGERS};
+use super::RequestType;
+
+#[derive(Serialize, PartialEq, Debug)]
+pub struct LedgersFreezeOperation {
+    #[serde(rename = "type")]
+    pub _type: String,
+    pub ledgers_ids: Vec<u64>,
+}
+
+impl LedgersFreezeOperation {
+    pub fn new(ledgers_ids: Vec<u64>) -> LedgersFreezeOperation {
+        LedgersFreezeOperation {
+            _type: LEDGERS_FREEZE.to_string(),
+            ledgers_ids
+        }
+    }
+}
+
+impl RequestType for LedgersFreezeOperation {
+    fn get_txn_type<'a>() -> &'a str {
+        LEDGERS_FREEZE
+    }
+}
+
+#[derive(Serialize, PartialEq, Debug)]
+pub struct GetFrozenLedgersOperation {
+    #[serde(rename = "type")]
+    pub _type: String
+}
+
+impl GetFrozenLedgersOperation {
+    pub fn new() -> GetFrozenLedgersOperation {
+        GetFrozenLedgersOperation {
+            _type: GET_FROZEN_LEDGERS.to_string()
+        }
+    }
+}
+
+impl RequestType for GetFrozenLedgersOperation {
+    fn get_txn_type<'a>() -> &'a str {
+        GET_FROZEN_LEDGERS
+    }
+}

--- a/libindy_vdr/src/ledger/requests/ledgers_freeze.rs
+++ b/libindy_vdr/src/ledger/requests/ledgers_freeze.rs
@@ -1,4 +1,4 @@
-use super::constants::{LEDGERS_FREEZE, GET_FROZEN_LEDGERS};
+use super::constants::{GET_FROZEN_LEDGERS, LEDGERS_FREEZE};
 use super::RequestType;
 
 #[derive(Serialize, PartialEq, Debug)]
@@ -12,7 +12,7 @@ impl LedgersFreezeOperation {
     pub fn new(ledgers_ids: Vec<u64>) -> LedgersFreezeOperation {
         LedgersFreezeOperation {
             _type: LEDGERS_FREEZE.to_string(),
-            ledgers_ids
+            ledgers_ids,
         }
     }
 }
@@ -26,13 +26,13 @@ impl RequestType for LedgersFreezeOperation {
 #[derive(Serialize, PartialEq, Debug)]
 pub struct GetFrozenLedgersOperation {
     #[serde(rename = "type")]
-    pub _type: String
+    pub _type: String,
 }
 
 impl GetFrozenLedgersOperation {
     pub fn new() -> GetFrozenLedgersOperation {
         GetFrozenLedgersOperation {
-            _type: GET_FROZEN_LEDGERS.to_string()
+            _type: GET_FROZEN_LEDGERS.to_string(),
         }
     }
 }

--- a/libindy_vdr/src/ledger/requests/mod.rs
+++ b/libindy_vdr/src/ledger/requests/mod.rs
@@ -6,6 +6,8 @@ pub mod auth_rule;
 pub mod author_agreement;
 /// Credential definition operations
 pub mod cred_def;
+/// Frozen Ledger operations
+pub mod ledgers_freeze;
 /// NODE transactions operations
 pub mod node;
 /// NYM transaction operations

--- a/libindy_vdr/tests/freeze_ledger.rs
+++ b/libindy_vdr/tests/freeze_ledger.rs
@@ -1,0 +1,57 @@
+#[macro_use]
+mod utils;
+
+inject_dependencies!();
+
+use indy_vdr::ledger::constants;
+use indy_vdr::utils::did::DidValue;
+
+use crate::utils::fixtures::*;
+
+#[test]
+fn empty() {
+    // Empty test to run module
+}
+
+#[cfg(test)]
+mod builder {
+    use super::*;
+    use indy_vdr::ledger::RequestBuilder;
+
+    mod freeze_ledger {
+        use super::*;
+        use crate::utils::helpers::check_request_operation;
+
+        #[rstest]
+        fn test_freeze_ledger_request(request_builder: RequestBuilder, trustee_did: DidValue) {
+            let ledgers_ids = vec![0, 1, 50, 873];
+
+            let request = request_builder
+                .build_ledger_freeze_request(&trustee_did, &ledgers_ids)
+                .unwrap();
+
+            let expected_operation = json!({
+                "type": constants::LEDGERS_FREEZE,
+                "ledgers_ids": ledgers_ids
+            });
+            check_request_operation(&request, expected_operation);
+        }
+    }
+
+    mod get_frozen_ledgers {
+        use super::*;
+        use crate::utils::helpers::check_request_operation;
+
+        #[rstest]
+        fn test_get_frozen_ledgers_request(request_builder: RequestBuilder, trustee_did: DidValue) {
+            let request = request_builder
+                .build_get_frozen_ledgers_request(&trustee_did)
+                .unwrap();
+
+            let expected_operation = json!({
+                "type": constants::GET_FROZEN_LEDGERS,
+            });
+            check_request_operation(&request, expected_operation);
+        }
+    }
+}


### PR DESCRIPTION
Updated `Request Builder` to provide methods for building `FREEZE_LEDGER` and `GET_FROZEN_LEDGER_REQUESTS` requests. 
Currently, methods are only available in RUST API because it seems that Ledger Admin specific methods are not exposed in C / wrappers API.    