### PR TITLE
chore(js): add @hyperledger prefix

### DIFF
--- a/wrappers/javascript/indy-vdr-nodejs/README.md
+++ b/wrappers/javascript/indy-vdr-nodejs/README.md
@@ -15,7 +15,7 @@ yarn add @hyperledger/indy-vdr-nodejs
 
 ## Usage
 
-You can import all types and classes from the `indy-vdr-nodejs` library:
+You can import all types and classes from the `@hyperledger/indy-vdr-nodejs` library:
 
 ```typescript
 import { PoolCreate, GetSchemaRequest } from '@hyperledger/indy-vdr-nodejs'
@@ -33,4 +33,4 @@ const getSchemaRequest = new GetSchemaRequest({
 const schemaResponse = await pool.submitRequest(getSchemaRequest)
 ```
 
-> **Note**: If you want to use this library in a cross-platform environment you need to import methods from the `@hyperledger/indy-vdr-shared` package instead. This is a platform independent package that allows to register the native bindings. The `@hyperledger/indy-vdr-nodejs` package uses this package under the hood. See the [Indy VDR Shared README](https://github.com/hyperledger/indy-vdr/tree/main/wrappers/javascript/shared/README.md) for documentation on how to use this package.
+> **Note**: If you want to use this library in a cross-platform environment you need to import methods from the `@hyperledger/indy-vdr-shared` package instead. This is a platform independent package that allows to register the native bindings. The `@hyperledger/indy-vdr-nodejs` package uses this package under the hood. See the [Indy VDR Shared README](https://github.com/hyperledger/indy-vdr/tree/main/wrappers/javascript/indy-vdr-shared/README.md) for documentation on how to use this package.

--- a/wrappers/javascript/indy-vdr-nodejs/README.md
+++ b/wrappers/javascript/indy-vdr-nodejs/README.md
@@ -1,4 +1,4 @@
-# indy-vdr-nodejs
+# Indy VDR NodeJS
 
 Wrapper for Nodejs around indy-vdr
 
@@ -10,7 +10,7 @@ Older and newer versions might also work, but they have not been tested.
 ## Installation
 
 ```sh
-yarn add indy-vdr-nodejs
+yarn add @hyperledger/indy-vdr-nodejs
 ```
 
 ## Usage
@@ -18,7 +18,7 @@ yarn add indy-vdr-nodejs
 You can import all types and classes from the `indy-vdr-nodejs` library:
 
 ```typescript
-import { PoolCreate, GetSchemaRequest } from 'indy-vdr-nodejs'
+import { PoolCreate, GetSchemaRequest } from '@hyperledger/indy-vdr-nodejs'
 
 const pool = new PoolCreate({
   parameters: {
@@ -33,4 +33,4 @@ const getSchemaRequest = new GetSchemaRequest({
 const schemaResponse = await pool.submitRequest(getSchemaRequest)
 ```
 
-> **Note**: If you want to use this library in a cross-platform environment you need to import methods from the `indy-vdr-shared` package instead. This is a platform independent package that allows to register the native bindings. The `indy-vdr-react-native` package uses this package under the hood. See the [Indy VDR Shared README](https://github.com/hyperledger/indy-vdr/tree/main/wrappers/javascript/shared/README.md) for documentation on how to use this package.
+> **Note**: If you want to use this library in a cross-platform environment you need to import methods from the `@hyperledger/indy-vdr-shared` package instead. This is a platform independent package that allows to register the native bindings. The `@hyperledger/indy-vdr-nodejs` package uses this package under the hood. See the [Indy VDR Shared README](https://github.com/hyperledger/indy-vdr/tree/main/wrappers/javascript/shared/README.md) for documentation on how to use this package.

--- a/wrappers/javascript/indy-vdr-nodejs/jest.config.ts
+++ b/wrappers/javascript/indy-vdr-nodejs/jest.config.ts
@@ -4,8 +4,8 @@ const config: Config.InitialOptions = {
   verbose: true,
   testTimeout: 120000,
   moduleNameMapper: {
-    '^indy-vdr-shared$': '<rootDir>/../indy-vdr-shared/src',
-    '^indy-vdr-nodejs$': '<rootDir>/src',
+    '^@hyperledger/indy-vdr-shared$': '<rootDir>/../indy-vdr-shared/src',
+    '^@hyperledger/indy-vdr-nodejs$': '<rootDir>/src',
   },
 }
 

--- a/wrappers/javascript/indy-vdr-nodejs/package.json
+++ b/wrappers/javascript/indy-vdr-nodejs/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "indy-vdr-nodejs",
+  "name": "@hyperledger/indy-vdr-nodejs",
   "version": "0.1.0-dev.1",
   "license": "Apache-2.0",
   "description": "Nodejs wrapper for Indy Vdr",
@@ -45,7 +45,7 @@
   "dependencies": {
     "@mapbox/node-pre-gyp": "^1.0.10",
     "ffi-napi": "^4.0.3",
-    "indy-vdr-shared": "0.1.0-dev.1",
+    "@hyperledger/indy-vdr-shared": "0.1.0-dev.1",
     "ref-array-di": "^1.2.2",
     "ref-napi": "^3.0.3",
     "ref-struct-di": "^1.1.1"

--- a/wrappers/javascript/indy-vdr-nodejs/package.json
+++ b/wrappers/javascript/indy-vdr-nodejs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperledger/indy-vdr-nodejs",
-  "version": "0.1.0-dev.1",
+  "version": "0.1.0-dev.2",
   "license": "Apache-2.0",
   "description": "Nodejs wrapper for Indy Vdr",
   "source": "src/index",
@@ -43,9 +43,9 @@
     "typescript": "4.5.5"
   },
   "dependencies": {
+    "@hyperledger/indy-vdr-shared": "0.1.0-dev.2",
     "@mapbox/node-pre-gyp": "^1.0.10",
     "ffi-napi": "^4.0.3",
-    "@hyperledger/indy-vdr-shared": "0.1.0-dev.1",
     "ref-array-di": "^1.2.2",
     "ref-napi": "^3.0.3",
     "ref-struct-di": "^1.1.1"

--- a/wrappers/javascript/indy-vdr-nodejs/src/NodeJSIndyVdr.ts
+++ b/wrappers/javascript/indy-vdr-nodejs/src/NodeJSIndyVdr.ts
@@ -33,7 +33,7 @@ import type {
   TransactionAuthorAgreementRequestOptions,
   Transactions,
   Verifiers,
-} from 'indy-vdr-shared'
+} from '@hyperledger/indy-vdr-shared'
 
 import { handleError } from './error'
 import {

--- a/wrappers/javascript/indy-vdr-nodejs/src/error.ts
+++ b/wrappers/javascript/indy-vdr-nodejs/src/error.ts
@@ -1,6 +1,6 @@
-import type { IndyVdrErrorObject } from 'indy-vdr-shared'
+import type { IndyVdrErrorObject } from '@hyperledger/indy-vdr-shared'
 
-import { IndyVdrError } from 'indy-vdr-shared'
+import { IndyVdrError } from '@hyperledger/indy-vdr-shared'
 
 import { allocateString } from './ffi'
 import { nativeIndyVdr } from './library'

--- a/wrappers/javascript/indy-vdr-nodejs/src/index.ts
+++ b/wrappers/javascript/indy-vdr-nodejs/src/index.ts
@@ -1,8 +1,8 @@
-import { registerIndyVdr } from 'indy-vdr-shared'
+import { registerIndyVdr } from '@hyperledger/indy-vdr-shared'
 
 import { NodeJSIndyVdr } from './NodeJSIndyVdr'
 
 export const indyVdrNodeJS = new NodeJSIndyVdr()
 registerIndyVdr({ vdr: indyVdrNodeJS })
 
-export * from 'indy-vdr-shared'
+export * from '@hyperledger/indy-vdr-shared'

--- a/wrappers/javascript/indy-vdr-nodejs/tests/AcceptanceMechanismsRequest.test.ts
+++ b/wrappers/javascript/indy-vdr-nodejs/tests/AcceptanceMechanismsRequest.test.ts
@@ -1,8 +1,8 @@
-import type { IndyVdrPool } from 'indy-vdr-nodejs'
+import type { IndyVdrPool } from '@hyperledger/indy-vdr-nodejs'
+
+import { AcceptanceMechanismsRequest } from '@hyperledger/indy-vdr-nodejs'
 
 import { DID, setupPool } from './utils'
-
-import { AcceptanceMechanismsRequest } from 'indy-vdr-nodejs'
 
 describe('AcceptanceMechanismsRequest', () => {
   let pool: IndyVdrPool

--- a/wrappers/javascript/indy-vdr-nodejs/tests/AcceptanceMechanismsRequest.test.ts
+++ b/wrappers/javascript/indy-vdr-nodejs/tests/AcceptanceMechanismsRequest.test.ts
@@ -1,8 +1,8 @@
 import type { IndyVdrPool } from '@hyperledger/indy-vdr-nodejs'
 
-import { AcceptanceMechanismsRequest } from '@hyperledger/indy-vdr-nodejs'
-
 import { DID, setupPool } from './utils'
+
+import { AcceptanceMechanismsRequest } from '@hyperledger/indy-vdr-nodejs'
 
 describe('AcceptanceMechanismsRequest', () => {
   let pool: IndyVdrPool

--- a/wrappers/javascript/indy-vdr-nodejs/tests/AttribRequest.test.ts
+++ b/wrappers/javascript/indy-vdr-nodejs/tests/AttribRequest.test.ts
@@ -1,8 +1,8 @@
-import type { IndyVdrPool } from 'indy-vdr-nodejs'
+import type { IndyVdrPool } from '@hyperledger/indy-vdr-nodejs'
 
 import { DID, setupPool } from './utils'
 
-import { AttribRequest } from 'indy-vdr-nodejs'
+import { AttribRequest } from '@hyperledger/indy-vdr-nodejs'
 
 describe('AttribRequest', () => {
   let pool: IndyVdrPool

--- a/wrappers/javascript/indy-vdr-nodejs/tests/CredentialDefinitionRequest.test.ts
+++ b/wrappers/javascript/indy-vdr-nodejs/tests/CredentialDefinitionRequest.test.ts
@@ -1,8 +1,8 @@
-import type { IndyVdrPool } from 'indy-vdr-nodejs'
+import type { IndyVdrPool } from '@hyperledger/indy-vdr-nodejs'
 
 import { DID, setupPool } from './utils'
 
-import { CredentialDefinitionRequest } from 'indy-vdr-nodejs'
+import { CredentialDefinitionRequest } from '@hyperledger/indy-vdr-nodejs'
 
 describe('CredentialDefinitionRequest', () => {
   let pool: IndyVdrPool

--- a/wrappers/javascript/indy-vdr-nodejs/tests/CustomRequest.test.ts
+++ b/wrappers/javascript/indy-vdr-nodejs/tests/CustomRequest.test.ts
@@ -1,8 +1,8 @@
-import type { IndyVdrPool } from 'indy-vdr-nodejs'
+import type { IndyVdrPool } from '@hyperledger/indy-vdr-nodejs'
+
+import { CustomRequest } from '@hyperledger/indy-vdr-nodejs'
 
 import { DID, setupPool } from './utils'
-
-import { CustomRequest } from 'indy-vdr-nodejs'
 
 describe('CustomRequest', () => {
   let pool: IndyVdrPool

--- a/wrappers/javascript/indy-vdr-nodejs/tests/CustomRequest.test.ts
+++ b/wrappers/javascript/indy-vdr-nodejs/tests/CustomRequest.test.ts
@@ -1,8 +1,8 @@
 import type { IndyVdrPool } from '@hyperledger/indy-vdr-nodejs'
 
-import { CustomRequest } from '@hyperledger/indy-vdr-nodejs'
-
 import { DID, setupPool } from './utils'
+
+import { CustomRequest } from '@hyperledger/indy-vdr-nodejs'
 
 describe('CustomRequest', () => {
   let pool: IndyVdrPool

--- a/wrappers/javascript/indy-vdr-nodejs/tests/DisableAllTransactionAuthorAgreementsRequest.test.ts
+++ b/wrappers/javascript/indy-vdr-nodejs/tests/DisableAllTransactionAuthorAgreementsRequest.test.ts
@@ -1,8 +1,8 @@
-import type { IndyVdrPool } from 'indy-vdr-nodejs'
+import type { IndyVdrPool } from '@hyperledger/indy-vdr-nodejs'
 
 import { DID, setupPool } from './utils'
 
-import { DisableAllTransactionAuthorAgreementsRequest } from 'indy-vdr-nodejs'
+import { DisableAllTransactionAuthorAgreementsRequest } from '@hyperledger/indy-vdr-nodejs'
 
 describe('DisableAllTransactionsAuthorAgreementRequest', () => {
   let pool: IndyVdrPool

--- a/wrappers/javascript/indy-vdr-nodejs/tests/GetAcceptanceMechanismsRequest.test.ts
+++ b/wrappers/javascript/indy-vdr-nodejs/tests/GetAcceptanceMechanismsRequest.test.ts
@@ -1,8 +1,8 @@
-import type { GetAcceptanceMechanismsResponse, IndyVdrPool } from 'indy-vdr-nodejs'
+import type { GetAcceptanceMechanismsResponse, IndyVdrPool } from '@hyperledger/indy-vdr-nodejs'
 
 import { setupPool } from './utils'
 
-import { GetAcceptanceMechanismsRequest } from 'indy-vdr-nodejs'
+import { GetAcceptanceMechanismsRequest } from '@hyperledger/indy-vdr-nodejs'
 
 describe('GetAcceptanceMechanismsRequest', () => {
   let pool: IndyVdrPool

--- a/wrappers/javascript/indy-vdr-nodejs/tests/GetAttribRequest.test.ts
+++ b/wrappers/javascript/indy-vdr-nodejs/tests/GetAttribRequest.test.ts
@@ -1,8 +1,8 @@
 import type { GetAttribResponse, IndyVdrPool } from '@hyperledger/indy-vdr-nodejs'
 
-import { GetAttribRequest } from '@hyperledger/indy-vdr-nodejs'
-
 import { DID, setupPool } from './utils'
+
+import { GetAttribRequest } from '@hyperledger/indy-vdr-nodejs'
 
 describe('GetAttribRequest', () => {
   let pool: IndyVdrPool

--- a/wrappers/javascript/indy-vdr-nodejs/tests/GetAttribRequest.test.ts
+++ b/wrappers/javascript/indy-vdr-nodejs/tests/GetAttribRequest.test.ts
@@ -1,8 +1,8 @@
-import type { GetAttribResponse, IndyVdrPool } from 'indy-vdr-nodejs'
+import type { GetAttribResponse, IndyVdrPool } from '@hyperledger/indy-vdr-nodejs'
+
+import { GetAttribRequest } from '@hyperledger/indy-vdr-nodejs'
 
 import { DID, setupPool } from './utils'
-
-import { GetAttribRequest } from 'indy-vdr-nodejs'
 
 describe('GetAttribRequest', () => {
   let pool: IndyVdrPool

--- a/wrappers/javascript/indy-vdr-nodejs/tests/GetCredentialDefinitionRequest.test.ts
+++ b/wrappers/javascript/indy-vdr-nodejs/tests/GetCredentialDefinitionRequest.test.ts
@@ -1,8 +1,8 @@
-import type { GetCredentialDefinitionResponse, IndyVdrPool } from 'indy-vdr-nodejs'
+import type { GetCredentialDefinitionResponse, IndyVdrPool } from '@hyperledger/indy-vdr-nodejs'
 
 import { CRED_DEF_ID, setupPool } from './utils'
 
-import { GetCredentialDefinitionRequest } from 'indy-vdr-nodejs'
+import { GetCredentialDefinitionRequest } from '@hyperledger/indy-vdr-nodejs'
 
 describe('GetCredentialDefinitionRequest', () => {
   let pool: IndyVdrPool

--- a/wrappers/javascript/indy-vdr-nodejs/tests/GetNymRequest.test.ts
+++ b/wrappers/javascript/indy-vdr-nodejs/tests/GetNymRequest.test.ts
@@ -1,8 +1,8 @@
 import type { GetNymResponse, IndyVdrPool } from '@hyperledger/indy-vdr-nodejs'
 
-import { GetNymRequest } from '@hyperledger/indy-vdr-nodejs'
-
 import { DID, setupPool } from './utils'
+
+import { GetNymRequest } from '@hyperledger/indy-vdr-nodejs'
 
 describe('GetNymRequest', () => {
   let pool: IndyVdrPool

--- a/wrappers/javascript/indy-vdr-nodejs/tests/GetNymRequest.test.ts
+++ b/wrappers/javascript/indy-vdr-nodejs/tests/GetNymRequest.test.ts
@@ -1,8 +1,8 @@
-import type { GetNymResponse, IndyVdrPool } from 'indy-vdr-nodejs'
+import type { GetNymResponse, IndyVdrPool } from '@hyperledger/indy-vdr-nodejs'
+
+import { GetNymRequest } from '@hyperledger/indy-vdr-nodejs'
 
 import { DID, setupPool } from './utils'
-
-import { GetNymRequest } from 'indy-vdr-nodejs'
 
 describe('GetNymRequest', () => {
   let pool: IndyVdrPool

--- a/wrappers/javascript/indy-vdr-nodejs/tests/GetRevocationRegistryDefinitionRequest.test.ts
+++ b/wrappers/javascript/indy-vdr-nodejs/tests/GetRevocationRegistryDefinitionRequest.test.ts
@@ -1,8 +1,8 @@
-import type { IndyVdrPool, GetRevocationRegistryDefinitionResponse } from 'indy-vdr-nodejs'
+import type { IndyVdrPool, GetRevocationRegistryDefinitionResponse } from '@hyperledger/indy-vdr-nodejs'
 
 import { REVOC_REG_DEF_ID, setupPool } from './utils'
 
-import { GetRevocationRegistryDefinitionRequest } from 'indy-vdr-nodejs'
+import { GetRevocationRegistryDefinitionRequest } from '@hyperledger/indy-vdr-nodejs'
 
 describe('GetRevocationRegistryDefinitionRequest', () => {
   let pool: IndyVdrPool

--- a/wrappers/javascript/indy-vdr-nodejs/tests/GetRevocationRegistryDeltaRequest.test.ts
+++ b/wrappers/javascript/indy-vdr-nodejs/tests/GetRevocationRegistryDeltaRequest.test.ts
@@ -1,8 +1,8 @@
-import type { GetRevocationRegistryDeltaResponse, IndyVdrPool } from 'indy-vdr-nodejs'
+import type { GetRevocationRegistryDeltaResponse, IndyVdrPool } from '@hyperledger/indy-vdr-nodejs'
 
 import { REVOC_REG_DEF_ID, setupPool } from './utils'
 
-import { GetRevocationRegistryDeltaRequest } from 'indy-vdr-nodejs'
+import { GetRevocationRegistryDeltaRequest } from '@hyperledger/indy-vdr-nodejs'
 
 describe('GetRevocationRegistryDeltaRequest', () => {
   let pool: IndyVdrPool

--- a/wrappers/javascript/indy-vdr-nodejs/tests/GetRevocationRegistryRequest.test.ts
+++ b/wrappers/javascript/indy-vdr-nodejs/tests/GetRevocationRegistryRequest.test.ts
@@ -1,8 +1,8 @@
-import type { GetRevocationRegistryResponse, IndyVdrPool } from 'indy-vdr-nodejs'
+import type { GetRevocationRegistryResponse, IndyVdrPool } from '@hyperledger/indy-vdr-nodejs'
 
 import { REVOC_REG_DEF_ID, setupPool } from './utils'
 
-import { GetRevocationRegistryRequest } from 'indy-vdr-nodejs'
+import { GetRevocationRegistryRequest } from '@hyperledger/indy-vdr-nodejs'
 
 describe('GetRevocationRegistryRequest', () => {
   let pool: IndyVdrPool

--- a/wrappers/javascript/indy-vdr-nodejs/tests/GetSchemaRequest.test.ts
+++ b/wrappers/javascript/indy-vdr-nodejs/tests/GetSchemaRequest.test.ts
@@ -1,8 +1,8 @@
 import type { GetSchemaResponse, IndyVdrPool } from '@hyperledger/indy-vdr-nodejs'
 
-import { GetSchemaRequest } from '@hyperledger/indy-vdr-nodejs'
-
 import { SCHEMA_ID, setupPool } from './utils'
+
+import { GetSchemaRequest } from '@hyperledger/indy-vdr-nodejs'
 
 describe('GetSchemaRequest', () => {
   let pool: IndyVdrPool

--- a/wrappers/javascript/indy-vdr-nodejs/tests/GetSchemaRequest.test.ts
+++ b/wrappers/javascript/indy-vdr-nodejs/tests/GetSchemaRequest.test.ts
@@ -1,8 +1,8 @@
-import type { GetSchemaResponse, IndyVdrPool } from 'indy-vdr-nodejs'
+import type { GetSchemaResponse, IndyVdrPool } from '@hyperledger/indy-vdr-nodejs'
+
+import { GetSchemaRequest } from '@hyperledger/indy-vdr-nodejs'
 
 import { SCHEMA_ID, setupPool } from './utils'
-
-import { GetSchemaRequest } from 'indy-vdr-nodejs'
 
 describe('GetSchemaRequest', () => {
   let pool: IndyVdrPool

--- a/wrappers/javascript/indy-vdr-nodejs/tests/GetTransactionAuthorAgreementRequest.test.ts
+++ b/wrappers/javascript/indy-vdr-nodejs/tests/GetTransactionAuthorAgreementRequest.test.ts
@@ -1,8 +1,8 @@
-import type { GetTransactionAuthorAgreementResponse, IndyVdrPool } from 'indy-vdr-nodejs'
+import type { GetTransactionAuthorAgreementResponse, IndyVdrPool } from '@hyperledger/indy-vdr-nodejs'
 
 import { setupPool } from './utils'
 
-import { GetTransactionAuthorAgreementRequest } from 'indy-vdr-nodejs'
+import { GetTransactionAuthorAgreementRequest } from '@hyperledger/indy-vdr-nodejs'
 
 describe('GetTransactionAuthorAgreementRequest', () => {
   let pool: IndyVdrPool

--- a/wrappers/javascript/indy-vdr-nodejs/tests/GetTransactionRequest.test.ts
+++ b/wrappers/javascript/indy-vdr-nodejs/tests/GetTransactionRequest.test.ts
@@ -1,8 +1,8 @@
-import type { GetTransactionResponse, IndyVdrPool } from 'indy-vdr-nodejs'
+import type { GetTransactionResponse, IndyVdrPool } from '@hyperledger/indy-vdr-nodejs'
+
+import { GetTransactionRequest } from '@hyperledger/indy-vdr-nodejs'
 
 import { setupPool } from './utils'
-
-import { GetTransactionRequest } from 'indy-vdr-nodejs'
 
 describe('GetTransactionRequest', () => {
   let pool: IndyVdrPool

--- a/wrappers/javascript/indy-vdr-nodejs/tests/GetTransactionRequest.test.ts
+++ b/wrappers/javascript/indy-vdr-nodejs/tests/GetTransactionRequest.test.ts
@@ -1,8 +1,8 @@
 import type { GetTransactionResponse, IndyVdrPool } from '@hyperledger/indy-vdr-nodejs'
 
-import { GetTransactionRequest } from '@hyperledger/indy-vdr-nodejs'
-
 import { setupPool } from './utils'
+
+import { GetTransactionRequest } from '@hyperledger/indy-vdr-nodejs'
 
 describe('GetTransactionRequest', () => {
   let pool: IndyVdrPool

--- a/wrappers/javascript/indy-vdr-nodejs/tests/GetValidatorInfoAction.test.ts
+++ b/wrappers/javascript/indy-vdr-nodejs/tests/GetValidatorInfoAction.test.ts
@@ -1,8 +1,8 @@
-import type { GetValidatorInfoResponse, IndyVdrPool } from 'indy-vdr-nodejs'
+import type { GetValidatorInfoResponse, IndyVdrPool } from '@hyperledger/indy-vdr-nodejs'
+
+import { GetValidatorInfoAction } from '@hyperledger/indy-vdr-nodejs'
 
 import { DID, setupPool } from './utils'
-
-import { GetValidatorInfoAction } from 'indy-vdr-nodejs'
 
 describe('GetValidatorInfoAction', () => {
   let pool: IndyVdrPool

--- a/wrappers/javascript/indy-vdr-nodejs/tests/GetValidatorInfoAction.test.ts
+++ b/wrappers/javascript/indy-vdr-nodejs/tests/GetValidatorInfoAction.test.ts
@@ -1,8 +1,8 @@
 import type { GetValidatorInfoResponse, IndyVdrPool } from '@hyperledger/indy-vdr-nodejs'
 
-import { GetValidatorInfoAction } from '@hyperledger/indy-vdr-nodejs'
-
 import { DID, setupPool } from './utils'
+
+import { GetValidatorInfoAction } from '@hyperledger/indy-vdr-nodejs'
 
 describe('GetValidatorInfoAction', () => {
   let pool: IndyVdrPool

--- a/wrappers/javascript/indy-vdr-nodejs/tests/IndyVdrPool.test.ts
+++ b/wrappers/javascript/indy-vdr-nodejs/tests/IndyVdrPool.test.ts
@@ -3,9 +3,9 @@
 
 import type { IndyVdrPool } from '@hyperledger/indy-vdr-nodejs'
 
-import { PoolCreate } from '@hyperledger/indy-vdr-nodejs'
-
 import { SOVRIN_GENESIS_TRANSACTION_BUILDER_NET } from './utils'
+
+import { PoolCreate } from '@hyperledger/indy-vdr-nodejs'
 
 describe('IndyVdrPool', () => {
   let pool: IndyVdrPool

--- a/wrappers/javascript/indy-vdr-nodejs/tests/IndyVdrPool.test.ts
+++ b/wrappers/javascript/indy-vdr-nodejs/tests/IndyVdrPool.test.ts
@@ -1,11 +1,11 @@
 // TODO: this should be turned off at a eslint config level for tests
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
 
-import type { IndyVdrPool } from 'indy-vdr-nodejs'
+import type { IndyVdrPool } from '@hyperledger/indy-vdr-nodejs'
+
+import { PoolCreate } from '@hyperledger/indy-vdr-nodejs'
 
 import { SOVRIN_GENESIS_TRANSACTION_BUILDER_NET } from './utils'
-
-import { PoolCreate } from 'indy-vdr-nodejs'
 
 describe('IndyVdrPool', () => {
   let pool: IndyVdrPool

--- a/wrappers/javascript/indy-vdr-nodejs/tests/IndyVdrRequest.test.ts
+++ b/wrappers/javascript/indy-vdr-nodejs/tests/IndyVdrRequest.test.ts
@@ -1,10 +1,10 @@
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
 
-import type { IndyVdrRequest } from 'indy-vdr-nodejs'
+import type { IndyVdrRequest } from '@hyperledger/indy-vdr-nodejs'
+
+import { GetSchemaRequest } from '@hyperledger/indy-vdr-nodejs'
 
 import { DID, SCHEMA_ID } from './utils'
-
-import { GetSchemaRequest } from 'indy-vdr-nodejs'
 
 describe('IndyVdrRequest', () => {
   let request: IndyVdrRequest

--- a/wrappers/javascript/indy-vdr-nodejs/tests/IndyVdrRequest.test.ts
+++ b/wrappers/javascript/indy-vdr-nodejs/tests/IndyVdrRequest.test.ts
@@ -2,9 +2,9 @@
 
 import type { IndyVdrRequest } from '@hyperledger/indy-vdr-nodejs'
 
-import { GetSchemaRequest } from '@hyperledger/indy-vdr-nodejs'
-
 import { DID, SCHEMA_ID } from './utils'
+
+import { GetSchemaRequest } from '@hyperledger/indy-vdr-nodejs'
 
 describe('IndyVdrRequest', () => {
   let request: IndyVdrRequest

--- a/wrappers/javascript/indy-vdr-nodejs/tests/NymRequest.test.ts
+++ b/wrappers/javascript/indy-vdr-nodejs/tests/NymRequest.test.ts
@@ -1,8 +1,8 @@
-import type { IndyVdrPool } from 'indy-vdr-nodejs'
+import type { IndyVdrPool } from '@hyperledger/indy-vdr-nodejs'
+
+import { NymRequest } from '@hyperledger/indy-vdr-nodejs'
 
 import { DID, setupPool } from './utils'
-
-import { NymRequest } from 'indy-vdr-nodejs'
 
 describe('NymRequest', () => {
   let pool: IndyVdrPool

--- a/wrappers/javascript/indy-vdr-nodejs/tests/NymRequest.test.ts
+++ b/wrappers/javascript/indy-vdr-nodejs/tests/NymRequest.test.ts
@@ -1,8 +1,8 @@
 import type { IndyVdrPool } from '@hyperledger/indy-vdr-nodejs'
 
-import { NymRequest } from '@hyperledger/indy-vdr-nodejs'
-
 import { DID, setupPool } from './utils'
+
+import { NymRequest } from '@hyperledger/indy-vdr-nodejs'
 
 describe('NymRequest', () => {
   let pool: IndyVdrPool

--- a/wrappers/javascript/indy-vdr-nodejs/tests/RevocationRegistryDefinitionRequest.test.ts
+++ b/wrappers/javascript/indy-vdr-nodejs/tests/RevocationRegistryDefinitionRequest.test.ts
@@ -1,8 +1,8 @@
-import type { IndyVdrPool } from 'indy-vdr-nodejs'
+import type { IndyVdrPool } from '@hyperledger/indy-vdr-nodejs'
 
 import { CRED_DEF_ID, DID, setupPool } from './utils'
 
-import { RevocationRegistryDefinitionRequest } from 'indy-vdr-nodejs'
+import { RevocationRegistryDefinitionRequest } from '@hyperledger/indy-vdr-nodejs'
 
 describe('RevocationRegistryDefinitionRequest', () => {
   let pool: IndyVdrPool

--- a/wrappers/javascript/indy-vdr-nodejs/tests/RevocationRegistryEntryRequest.test.ts
+++ b/wrappers/javascript/indy-vdr-nodejs/tests/RevocationRegistryEntryRequest.test.ts
@@ -1,8 +1,8 @@
 import type { IndyVdrPool } from '@hyperledger/indy-vdr-nodejs'
 
-import { RevocationRegistryEntryRequest } from '@hyperledger/indy-vdr-nodejs'
-
 import { DID, REVOC_REG_DEF_ID, setupPool } from './utils'
+
+import { RevocationRegistryEntryRequest } from '@hyperledger/indy-vdr-nodejs'
 
 describe('RevocationRegistryEntryRequest', () => {
   let pool: IndyVdrPool

--- a/wrappers/javascript/indy-vdr-nodejs/tests/RevocationRegistryEntryRequest.test.ts
+++ b/wrappers/javascript/indy-vdr-nodejs/tests/RevocationRegistryEntryRequest.test.ts
@@ -1,8 +1,8 @@
-import type { IndyVdrPool } from 'indy-vdr-nodejs'
+import type { IndyVdrPool } from '@hyperledger/indy-vdr-nodejs'
+
+import { RevocationRegistryEntryRequest } from '@hyperledger/indy-vdr-nodejs'
 
 import { DID, REVOC_REG_DEF_ID, setupPool } from './utils'
-
-import { RevocationRegistryEntryRequest } from 'indy-vdr-nodejs'
 
 describe('RevocationRegistryEntryRequest', () => {
   let pool: IndyVdrPool

--- a/wrappers/javascript/indy-vdr-nodejs/tests/SchemaRequest.test.ts
+++ b/wrappers/javascript/indy-vdr-nodejs/tests/SchemaRequest.test.ts
@@ -1,8 +1,8 @@
-import type { IndyVdrPool } from 'indy-vdr-nodejs'
+import type { IndyVdrPool } from '@hyperledger/indy-vdr-nodejs'
 
 import { DID, SCHEMA_ID, setupPool } from './utils'
 
-import { SchemaRequest } from 'indy-vdr-nodejs'
+import { SchemaRequest } from '@hyperledger/indy-vdr-nodejs'
 
 describe('SchemaRequest', () => {
   let pool: IndyVdrPool

--- a/wrappers/javascript/indy-vdr-nodejs/tests/TransactionAuthorAgreementRequest.test.ts
+++ b/wrappers/javascript/indy-vdr-nodejs/tests/TransactionAuthorAgreementRequest.test.ts
@@ -1,8 +1,8 @@
-import type { IndyVdrPool } from 'indy-vdr-nodejs'
+import type { IndyVdrPool } from '@hyperledger/indy-vdr-nodejs'
+
+import { TransactionAuthorAgreementRequest } from '@hyperledger/indy-vdr-nodejs'
 
 import { DID, setupPool } from './utils'
-
-import { TransactionAuthorAgreementRequest } from 'indy-vdr-nodejs'
 
 describe('TransactionAuthorAgreementRequest', () => {
   let pool: IndyVdrPool

--- a/wrappers/javascript/indy-vdr-nodejs/tests/TransactionAuthorAgreementRequest.test.ts
+++ b/wrappers/javascript/indy-vdr-nodejs/tests/TransactionAuthorAgreementRequest.test.ts
@@ -1,8 +1,8 @@
 import type { IndyVdrPool } from '@hyperledger/indy-vdr-nodejs'
 
-import { TransactionAuthorAgreementRequest } from '@hyperledger/indy-vdr-nodejs'
-
 import { DID, setupPool } from './utils'
+
+import { TransactionAuthorAgreementRequest } from '@hyperledger/indy-vdr-nodejs'
 
 describe('TransactionAuthorAgreementRequest', () => {
   let pool: IndyVdrPool

--- a/wrappers/javascript/indy-vdr-nodejs/tests/utils/initialize.ts
+++ b/wrappers/javascript/indy-vdr-nodejs/tests/utils/initialize.ts
@@ -1,4 +1,4 @@
-import { PoolCreate } from 'indy-vdr-shared'
+import { PoolCreate } from '@hyperledger/indy-vdr-shared'
 
 import { SOVRIN_GENESIS_TRANSACTION_BUILDER_NET } from './fixtures'
 

--- a/wrappers/javascript/indy-vdr-react-native/README.md
+++ b/wrappers/javascript/indy-vdr-react-native/README.md
@@ -34,4 +34,4 @@ const getSchemaRequest = new GetSchemaRequest({
 const schemaResponse = await pool.submitRequest(getSchemaRequest)
 ```
 
-> **Note**: If you want to use this library in a cross-platform environment you need to import methods from the `@hyperledger/indy-vdr-shared` package instead. This is a platform independent package that allows to register the native bindings. The `@hyperledger/indy-vdr-react-native` package uses this package under the hood. See the [Indy VDR Shared README](https://github.com/hyperledger/indy-vdr/tree/main/wrappers/javascript/shared/README.md) for documentation on how to use this package.
+> **Note**: If you want to use this library in a cross-platform environment you need to import methods from the `@hyperledger/indy-vdr-shared` package instead. This is a platform independent package that allows to register the native bindings. The `@hyperledger/indy-vdr-react-native` package uses this package under the hood. See the [Indy VDR Shared README](https://github.com/hyperledger/indy-vdr/tree/main/wrappers/javascript/indy-vdr-shared/README.md) for documentation on how to use this package.

--- a/wrappers/javascript/indy-vdr-react-native/README.md
+++ b/wrappers/javascript/indy-vdr-react-native/README.md
@@ -1,4 +1,4 @@
-# indy-vdr-react-native
+# Indy VDR React Native
 
 Wrapper for React Native around indy-vdr
 
@@ -11,15 +11,15 @@ version of `>= 0.66.0` is required for this package to work.
 ## Installation
 
 ```sh
-yarn add indy-vdr-react-native
+yarn add @hyperledger/indy-vdr-react-native
 ```
 
 ## Usage
 
-You can import all types and classes from the `indy-vdr-react-native` library:
+You can import all types and classes from the `@hyperledger/indy-vdr-react-native` library:
 
 ```typescript
-import { PoolCreate, GetSchemaRequest } from 'indy-vdr-react-native'
+import { PoolCreate, GetSchemaRequest } from '@hyperledger/indy-vdr-react-native'
 
 const pool = new PoolCreate({
   parameters: {
@@ -34,4 +34,4 @@ const getSchemaRequest = new GetSchemaRequest({
 const schemaResponse = await pool.submitRequest(getSchemaRequest)
 ```
 
-> **Note**: If you want to use this library in a cross-platform environment you need to import methods from the `indy-vdr-shared` package instead. This is a platform independent package that allows to register the native bindings. The `indy-vdr-nodejs` package uses this package under the hood. See the [Indy VDR Shared README](https://github.com/hyperledger/indy-vdr/tree/main/wrappers/javascript/shared/README.md) for documentation on how to use this package.
+> **Note**: If you want to use this library in a cross-platform environment you need to import methods from the `@hyperledger/indy-vdr-shared` package instead. This is a platform independent package that allows to register the native bindings. The `@hyperledger/indy-vdr-react-native` package uses this package under the hood. See the [Indy VDR Shared README](https://github.com/hyperledger/indy-vdr/tree/main/wrappers/javascript/shared/README.md) for documentation on how to use this package.

--- a/wrappers/javascript/indy-vdr-react-native/package.json
+++ b/wrappers/javascript/indy-vdr-react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperledger/indy-vdr-react-native",
-  "version": "0.1.0-dev.1",
+  "version": "0.1.0-dev.2",
   "license": "Apache-2.0",
   "description": "React Native wrapper for Indy Vdr",
   "source": "src/index",
@@ -40,8 +40,8 @@
     "install": "node-pre-gyp install"
   },
   "dependencies": {
-    "@mapbox/node-pre-gyp": "^1.0.10",
-    "@hyperledger/indy-vdr-shared": "0.1.0-dev.1"
+    "@hyperledger/indy-vdr-shared": "0.1.0-dev.2",
+    "@mapbox/node-pre-gyp": "^1.0.10"
   },
   "devDependencies": {
     "@types/react": "^16.9.19",

--- a/wrappers/javascript/indy-vdr-react-native/package.json
+++ b/wrappers/javascript/indy-vdr-react-native/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "indy-vdr-react-native",
+  "name": "@hyperledger/indy-vdr-react-native",
   "version": "0.1.0-dev.1",
   "license": "Apache-2.0",
   "description": "React Native wrapper for Indy Vdr",
@@ -41,7 +41,7 @@
   },
   "dependencies": {
     "@mapbox/node-pre-gyp": "^1.0.10",
-    "indy-vdr-shared": "0.1.0-dev.1"
+    "@hyperledger/indy-vdr-shared": "0.1.0-dev.1"
   },
   "devDependencies": {
     "@types/react": "^16.9.19",

--- a/wrappers/javascript/indy-vdr-react-native/src/ReactNativeIndyVdr.ts
+++ b/wrappers/javascript/indy-vdr-react-native/src/ReactNativeIndyVdr.ts
@@ -34,7 +34,7 @@ import type {
   TransactionAuthorAgreementRequestOptions,
   Transactions,
   Verifiers,
-} from 'indy-vdr-shared'
+} from '@hyperledger/indy-vdr-shared'
 
 import { indyVdrReactNative } from './library'
 import { serializeArguments } from './serialize'

--- a/wrappers/javascript/indy-vdr-react-native/src/index.ts
+++ b/wrappers/javascript/indy-vdr-react-native/src/index.ts
@@ -2,7 +2,7 @@
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
 
-import { registerIndyVdr } from 'indy-vdr-shared'
+import { registerIndyVdr } from '@hyperledger/indy-vdr-shared'
 import { NativeModules } from 'react-native'
 
 import { ReactNativeIndyVdr } from './ReactNativeIndyVdr'
@@ -10,7 +10,7 @@ import { ReactNativeIndyVdr } from './ReactNativeIndyVdr'
 const module = NativeModules.IndyVdr
 if (!module.install()) throw Error('Unable to install the turboModule: indyVdr')
 
-export * from 'indy-vdr-shared'
+export * from '@hyperledger/indy-vdr-shared'
 
 export const indyVdrReactNative = new ReactNativeIndyVdr()
 

--- a/wrappers/javascript/indy-vdr-react-native/src/library.ts
+++ b/wrappers/javascript/indy-vdr-react-native/src/library.ts
@@ -1,4 +1,4 @@
-import type { IndyVdrNativeBindings } from 'indy-vdr-shared'
+import type { IndyVdrNativeBindings } from '@hyperledger/indy-vdr-shared'
 
 // This can already check whether `_indy_vdr` exists on global
 // eslint-disable-next-line @typescript-eslint/no-use-before-define

--- a/wrappers/javascript/indy-vdr-shared/README.md
+++ b/wrappers/javascript/indy-vdr-shared/README.md
@@ -1,4 +1,4 @@
-# indy-vdr-shared
+# Indy VDR Shared
 
 This package does not contain any functionality, just the classes and types
 that wrap around the native NodeJS / React Native functionality
@@ -11,7 +11,7 @@ be used to create a ledger request. Following is a small example to request a
 schema from a ledger.
 
 ```typescript
-import { PoolCreate, GetSchemaRequest } from 'indy-vdr-shared'
+import { PoolCreate, GetSchemaRequest } from '@hyperledger/indy-vdr-shared'
 
 const pool = new PoolCreate({
   parameters: {
@@ -28,28 +28,28 @@ const schemaResponse = await pool.submitRequest(getSchemaRequest)
 
 ## Platform independent setup
 
-If you would like to leverage the Indy VDR libraries for JavaScript in a platform independent way you need to add the `indy-vdr-shared` package to your project. This package exports all public methods.
+If you would like to leverage the Indy VDR libraries for JavaScript in a platform independent way you need to add the `@hyperledger/indy-vdr-shared` package to your project. This package exports all public methods.
 
-Before calling any methods you then need to make sure you register the platform specific native bindings. You can do this by importing the platform specific package. You can do this by having separate files that register the package, which allows the React Native bundler to import a differnet package:
+Before calling any methods you then need to make sure you register the platform specific native bindings. You can do this by importing the platform specific package. You can do this by having separate files that register the package, which allows the React Native bundler to import a different package:
 
 ```typescript
 // register.ts
-import 'indy-vdr-nodejs'
+import '@hyperledger/indy-vdr-nodejs'
 ```
 
 ```typescript
 // register.native.ts
-import 'indy-vdr-react-native'
+import '@hyperledger/indy-vdr-react-native'
 ```
 
 An alterative approach is to first try to require the Node.JS package, and otherwise require the React Native package:
 
 ```typescript
 try {
-  require('indy-vdr-nodejs')
+  require('@hyperledger/indy-vdr-nodejs')
 } catch (error) {
   try {
-    require('indy-vdr-react-native')
+    require('@hyperledger/indy-vdr-react-native')
   } catch (error) {
     throw new Error('Could not load Indy VDR bindings')
   }

--- a/wrappers/javascript/indy-vdr-shared/package.json
+++ b/wrappers/javascript/indy-vdr-shared/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "indy-vdr-shared",
+  "name": "@hyperledger/indy-vdr-shared",
   "version": "0.1.0-dev.1",
   "license": "Apache-2.0",
   "description": "Shared library for using Indy VDR with NodeJS and React Native",

--- a/wrappers/javascript/indy-vdr-shared/package.json
+++ b/wrappers/javascript/indy-vdr-shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperledger/indy-vdr-shared",
-  "version": "0.1.0-dev.1",
+  "version": "0.1.0-dev.2",
   "license": "Apache-2.0",
   "description": "Shared library for using Indy VDR with NodeJS and React Native",
   "main": "build/index",

--- a/wrappers/javascript/lerna.json
+++ b/wrappers/javascript/lerna.json
@@ -1,6 +1,8 @@
 {
-  "packages": ["packages/*"],
-  "version": "0.1.0",
+  "packages": [
+    "packages/*"
+  ],
+  "version": "0.1.0-dev.2",
   "useWorkspaces": true,
   "npmClient": "yarn",
   "command": {

--- a/wrappers/javascript/lerna.json
+++ b/wrappers/javascript/lerna.json
@@ -1,7 +1,5 @@
 {
-  "packages": [
-    "packages/*"
-  ],
+  "packages": ["packages/*"],
   "version": "0.1.0-dev.2",
   "useWorkspaces": true,
   "npmClient": "yarn",

--- a/wrappers/javascript/tsconfig.eslint.json
+++ b/wrappers/javascript/tsconfig.eslint.json
@@ -3,9 +3,9 @@
   "compilerOptions": {
     "baseUrl": ".",
     "paths": {
-      "indy-vdr-shared": ["indy-vdr-shared/src"],
-      "indy-vdr-react-native": ["indy-vdr-react-native/src"],
-      "indy-vdr-nodejs": ["indy-vdr-nodejs/src"]
+      "@hyperledger/indy-vdr-shared": ["indy-vdr-shared/src"],
+      "@hyperledger/indy-vdr-react-native": ["indy-vdr-react-native/src"],
+      "@hyperledger/indy-vdr-nodejs": ["indy-vdr-nodejs/src"]
     }
   },
   "include": [".eslintrc.js"],

--- a/wrappers/javascript/tsconfig.json
+++ b/wrappers/javascript/tsconfig.json
@@ -3,9 +3,9 @@
   "compilerOptions": {
     "baseUrl": ".",
     "paths": {
-      "indy-vdr-shared": ["indy-vdr-shared/src"],
-      "indy-vdr-react-native": ["indy-vdr-react-native/src"],
-      "indy-vdr-nodejs": ["indy-vdr-nodejs/src"]
+      "@hyperledger/indy-vdr-shared": ["indy-vdr-shared/src"],
+      "@hyperledger/indy-vdr-react-native": ["indy-vdr-react-native/src"],
+      "@hyperledger/indy-vdr-nodejs": ["indy-vdr-nodejs/src"]
     }
   },
   "exclude": ["node_modules", "**/build/**", "build"]

--- a/wrappers/python/indy_vdr/version.py
+++ b/wrappers/python/indy_vdr/version.py
@@ -1,3 +1,3 @@
 """indy_vdr library wrapper version."""
 
-__version__ = "0.4.0.dev1"
+__version__ = "0.4.0.dev2"


### PR DESCRIPTION
Adds the `@hyperledger` prefix to all js packages and updates the version to `0.1.0-dev.2`. 

After this PR and #135 are merged would like to make another release.

I think we can just run the ci pipeline on main, do not publish binaries, but do public wrappers. Because python version insn't incresed I think it will just skip them?