### PR TITLE
Added missing reqeust builders into FFI and Python wrapper

### DIFF
--- a/libindy_vdr/src/ffi/ledger.rs
+++ b/libindy_vdr/src/ffi/ledger.rs
@@ -630,10 +630,10 @@ pub extern "C" fn indy_vdr_build_node_request(
 }
 
 #[no_mangle]
-pub extern "C" fn indy_vdr_build_pool_config(
+pub extern "C" fn indy_vdr_build_pool_config_request(
     identifier: FfiStr,
-    writes: bool,
-    force: bool,
+    writes: i8,
+    force: i8,
     handle_p: *mut RequestHandle,
 ) -> ErrorCode {
     catch_err! {
@@ -641,7 +641,7 @@ pub extern "C" fn indy_vdr_build_pool_config(
         check_useful_c_ptr!(handle_p);
         let builder = get_request_builder()?;
         let identifier = DidValue::from_str(identifier.as_str())?;
-        let req = builder.build_pool_config(&identifier, writes, force)?;
+        let req = builder.build_pool_config(&identifier, writes != 0, force != 0)?;
         let handle = add_request(req)?;
         unsafe {
             *handle_p = handle;
@@ -651,7 +651,7 @@ pub extern "C" fn indy_vdr_build_pool_config(
 }
 
 #[no_mangle]
-pub extern "C" fn indy_vdr_build_pool_restart(
+pub extern "C" fn indy_vdr_build_pool_restart_request(
     identifier: FfiStr,
     action: FfiStr,
     datetime: FfiStr,

--- a/libindy_vdr/src/ffi/ledger.rs
+++ b/libindy_vdr/src/ffi/ledger.rs
@@ -641,7 +641,7 @@ pub extern "C" fn indy_vdr_build_pool_config_request(
         check_useful_c_ptr!(handle_p);
         let builder = get_request_builder()?;
         let identifier = DidValue::from_str(identifier.as_str())?;
-        let req = builder.build_pool_config(&identifier, writes != 0, force != 0)?;
+        let req = builder.build_pool_config_request(&identifier, writes != 0, force != 0)?;
         let handle = add_request(req)?;
         unsafe {
             *handle_p = handle;
@@ -664,7 +664,7 @@ pub extern "C" fn indy_vdr_build_pool_restart_request(
         let identifier = DidValue::from_str(identifier.as_str())?;
         let action = action.as_str();
         let datetime = datetime.into_opt_string();
-        let req = builder.build_pool_restart(&identifier, action, datetime.as_deref())?;
+        let req = builder.build_pool_restart_request(&identifier, action, datetime.as_deref())?;
         let handle = add_request(req)?;
         unsafe {
             *handle_p = handle;

--- a/libindy_vdr/src/ledger/constants.rs
+++ b/libindy_vdr/src/ledger/constants.rs
@@ -6,6 +6,8 @@ pub const TXN_AUTHR_AGRMT_AML: &str = "5";
 pub const GET_TXN_AUTHR_AGRMT: &str = "6";
 pub const GET_TXN_AUTHR_AGRMT_AML: &str = "7";
 pub const DISABLE_ALL_TXN_AUTHR_AGRMTS: &str = "8";
+pub const LEDGERS_FREEZE: &str = "9";
+pub const GET_FROZEN_LEDGERS: &str = "10";
 pub const ATTRIB: &str = "100";
 pub const SCHEMA: &str = "101";
 pub const CRED_DEF: &str = "102";
@@ -36,7 +38,7 @@ pub const RICH_SCHEMA_PRES_DEF: &str = "205";
 pub const GET_RICH_SCHEMA_BY_ID: &str = "300";
 pub const GET_RICH_SCHEMA_BY_METADATA: &str = "301";
 
-pub const REQUESTS: [&str; 31] = [
+pub const REQUESTS: [&str; 33] = [
     NODE,
     NYM,
     GET_TXN,
@@ -62,6 +64,8 @@ pub const REQUESTS: [&str; 31] = [
     GET_TXN_AUTHR_AGRMT,
     GET_TXN_AUTHR_AGRMT_AML,
     DISABLE_ALL_TXN_AUTHR_AGRMTS,
+    LEDGERS_FREEZE,
+    GET_FROZEN_LEDGERS,
     RICH_SCHEMA_CTX,
     RICH_SCHEMA,
     RICH_SCHEMA_ENCODING,
@@ -132,6 +136,8 @@ pub fn txn_name_to_code(txn: &str) -> Option<&str> {
         "GET_TXN_AUTHR_AGRMT" => Some(GET_TXN_AUTHR_AGRMT),
         "GET_TXN_AUTHR_AGRMT_AML" => Some(GET_TXN_AUTHR_AGRMT_AML),
         "DISABLE_ALL_TXN_AUTHR_AGRMTS" => Some(DISABLE_ALL_TXN_AUTHR_AGRMTS),
+        "LEDGERS_FREEZE" => Some(LEDGERS_FREEZE),
+        "GET_FROZEN_LEDGERS" => Some(GET_FROZEN_LEDGERS),
         val => Some(val),
     }
 }

--- a/libindy_vdr/src/ledger/request_builder.rs
+++ b/libindy_vdr/src/ledger/request_builder.rs
@@ -606,7 +606,7 @@ impl RequestBuilder {
     }
 
     /// Build a `LEDGERS_FREEZE` transaction request
-    pub fn build_ledger_freeze_request(
+    pub fn build_ledgers_freeze_request(
         &self,
         identifier: &DidValue,
         ledgers_ids: &[u64],

--- a/libindy_vdr/src/ledger/request_builder.rs
+++ b/libindy_vdr/src/ledger/request_builder.rs
@@ -20,6 +20,7 @@ use super::requests::author_agreement::{
     TxnAuthorAgreementOperation, TxnAuthrAgrmtAcceptanceData,
 };
 use super::requests::cred_def::{CredDefOperation, CredentialDefinition, GetCredDefOperation};
+use super::requests::ledgers_freeze::{GetFrozenLedgersOperation, LedgersFreezeOperation};
 use super::requests::node::{NodeOperation, NodeOperationData};
 use super::requests::nym::{role_to_code, GetNymOperation, NymOperation};
 use super::requests::pool::{
@@ -44,7 +45,6 @@ use super::requests::schema::{
 use super::requests::txn::GetTxnOperation;
 use super::requests::validator_info::GetValidatorInfoOperation;
 use super::requests::{Request, RequestType};
-use super::requests::ledgers_freeze::{GetFrozenLedgersOperation, LedgersFreezeOperation};
 
 use super::constants::txn_name_to_code;
 
@@ -609,9 +609,12 @@ impl RequestBuilder {
     pub fn build_ledger_freeze_request(
         &self,
         identifier: &DidValue,
-        ledgers_ids: &[u64]
+        ledgers_ids: &[u64],
     ) -> VdrResult<PreparedRequest> {
-        self.build(LedgersFreezeOperation::new(ledgers_ids.to_vec()), Some(identifier))
+        self.build(
+            LedgersFreezeOperation::new(ledgers_ids.to_vec()),
+            Some(identifier),
+        )
     }
 
     /// Build a `GET_FROZEN_LEDGERS` transaction request

--- a/libindy_vdr/src/ledger/request_builder.rs
+++ b/libindy_vdr/src/ledger/request_builder.rs
@@ -207,7 +207,7 @@ impl RequestBuilder {
     }
 
     /// Build a `POOL_CONFIG` transaction request
-    pub fn build_pool_config(
+    pub fn build_pool_config_request(
         &self,
         identifier: &DidValue,
         writes: bool,
@@ -217,7 +217,7 @@ impl RequestBuilder {
     }
 
     /// Build a `POOL_RESTART` transaction request
-    pub fn build_pool_restart(
+    pub fn build_pool_restart_request(
         &self,
         identifier: &DidValue,
         action: &str,
@@ -230,7 +230,8 @@ impl RequestBuilder {
     }
 
     /// Build a `POOL_UPGRADE` transaction request
-    pub fn build_pool_upgrade(
+    #[allow(clippy::too_many_arguments)]
+    pub fn build_pool_upgrade_request(
         &self,
         identifier: &DidValue,
         name: &str,
@@ -260,6 +261,7 @@ impl RequestBuilder {
     }
 
     /// Build an `AUTH_RULE` transaction request
+    #[allow(clippy::too_many_arguments)]
     pub fn build_auth_rule_request(
         &self,
         submitter_did: &DidValue,
@@ -550,6 +552,7 @@ impl RequestBuilder {
     }
 
     #[cfg(any(feature = "rich_schema", test))]
+    #[allow(clippy::too_many_arguments)]
     /// Build a `RICH_SCHEMA` transaction request
     pub fn build_rich_schema_request(
         &self,

--- a/libindy_vdr/src/ledger/request_builder.rs
+++ b/libindy_vdr/src/ledger/request_builder.rs
@@ -44,6 +44,7 @@ use super::requests::schema::{
 use super::requests::txn::GetTxnOperation;
 use super::requests::validator_info::GetValidatorInfoOperation;
 use super::requests::{Request, RequestType};
+use super::requests::ledgers_freeze::{GetFrozenLedgersOperation, LedgersFreezeOperation};
 
 use super::constants::txn_name_to_code;
 
@@ -602,6 +603,23 @@ impl RequestBuilder {
             GetRichSchemaByMetadataOperation::new(get_rs_by_meta),
             Some(identifier),
         )
+    }
+
+    /// Build a `LEDGERS_FREEZE` transaction request
+    pub fn build_ledger_freeze_request(
+        &self,
+        identifier: &DidValue,
+        ledgers_ids: &[u64]
+    ) -> VdrResult<PreparedRequest> {
+        self.build(LedgersFreezeOperation::new(ledgers_ids.to_vec()), Some(identifier))
+    }
+
+    /// Build a `GET_FROZEN_LEDGERS` transaction request
+    pub fn build_get_frozen_ledgers_request(
+        &self,
+        identifier: &DidValue,
+    ) -> VdrResult<PreparedRequest> {
+        self.build(GetFrozenLedgersOperation::new(), Some(identifier))
     }
 }
 

--- a/libindy_vdr/src/ledger/requests/ledgers_freeze.rs
+++ b/libindy_vdr/src/ledger/requests/ledgers_freeze.rs
@@ -1,0 +1,44 @@
+use super::constants::{LEDGERS_FREEZE, GET_FROZEN_LEDGERS};
+use super::RequestType;
+
+#[derive(Serialize, PartialEq, Debug)]
+pub struct LedgersFreezeOperation {
+    #[serde(rename = "type")]
+    pub _type: String,
+    pub ledgers_ids: Vec<u64>,
+}
+
+impl LedgersFreezeOperation {
+    pub fn new(ledgers_ids: Vec<u64>) -> LedgersFreezeOperation {
+        LedgersFreezeOperation {
+            _type: LEDGERS_FREEZE.to_string(),
+            ledgers_ids
+        }
+    }
+}
+
+impl RequestType for LedgersFreezeOperation {
+    fn get_txn_type<'a>() -> &'a str {
+        LEDGERS_FREEZE
+    }
+}
+
+#[derive(Serialize, PartialEq, Debug)]
+pub struct GetFrozenLedgersOperation {
+    #[serde(rename = "type")]
+    pub _type: String
+}
+
+impl GetFrozenLedgersOperation {
+    pub fn new() -> GetFrozenLedgersOperation {
+        GetFrozenLedgersOperation {
+            _type: GET_FROZEN_LEDGERS.to_string()
+        }
+    }
+}
+
+impl RequestType for GetFrozenLedgersOperation {
+    fn get_txn_type<'a>() -> &'a str {
+        GET_FROZEN_LEDGERS
+    }
+}

--- a/libindy_vdr/src/ledger/requests/ledgers_freeze.rs
+++ b/libindy_vdr/src/ledger/requests/ledgers_freeze.rs
@@ -37,6 +37,12 @@ impl GetFrozenLedgersOperation {
     }
 }
 
+impl Default for GetFrozenLedgersOperation {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl RequestType for GetFrozenLedgersOperation {
     fn get_txn_type<'a>() -> &'a str {
         GET_FROZEN_LEDGERS

--- a/libindy_vdr/src/ledger/requests/ledgers_freeze.rs
+++ b/libindy_vdr/src/ledger/requests/ledgers_freeze.rs
@@ -1,4 +1,4 @@
-use super::constants::{LEDGERS_FREEZE, GET_FROZEN_LEDGERS};
+use super::constants::{GET_FROZEN_LEDGERS, LEDGERS_FREEZE};
 use super::RequestType;
 
 #[derive(Serialize, PartialEq, Debug)]
@@ -12,7 +12,7 @@ impl LedgersFreezeOperation {
     pub fn new(ledgers_ids: Vec<u64>) -> LedgersFreezeOperation {
         LedgersFreezeOperation {
             _type: LEDGERS_FREEZE.to_string(),
-            ledgers_ids
+            ledgers_ids,
         }
     }
 }
@@ -26,13 +26,13 @@ impl RequestType for LedgersFreezeOperation {
 #[derive(Serialize, PartialEq, Debug)]
 pub struct GetFrozenLedgersOperation {
     #[serde(rename = "type")]
-    pub _type: String
+    pub _type: String,
 }
 
 impl GetFrozenLedgersOperation {
     pub fn new() -> GetFrozenLedgersOperation {
         GetFrozenLedgersOperation {
-            _type: GET_FROZEN_LEDGERS.to_string()
+            _type: GET_FROZEN_LEDGERS.to_string(),
         }
     }
 }

--- a/libindy_vdr/src/ledger/requests/mod.rs
+++ b/libindy_vdr/src/ledger/requests/mod.rs
@@ -6,6 +6,8 @@ pub mod auth_rule;
 pub mod author_agreement;
 /// Credential definition operations
 pub mod cred_def;
+/// Frozen Ledger operations
+pub mod ledgers_freeze;
 /// NODE transactions operations
 pub mod node;
 /// NYM transaction operations

--- a/libindy_vdr/src/ledger/requests/pool.rs
+++ b/libindy_vdr/src/ledger/requests/pool.rs
@@ -75,6 +75,7 @@ pub struct PoolUpgradeOperation {
 }
 
 impl PoolUpgradeOperation {
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         name: &str,
         version: &str,

--- a/libindy_vdr/tests/freeze_ledger.rs
+++ b/libindy_vdr/tests/freeze_ledger.rs
@@ -1,0 +1,57 @@
+#[macro_use]
+mod utils;
+
+inject_dependencies!();
+
+use indy_vdr::ledger::constants;
+use indy_vdr::utils::did::DidValue;
+
+use crate::utils::fixtures::*;
+
+#[test]
+fn empty() {
+    // Empty test to run module
+}
+
+#[cfg(test)]
+mod builder {
+    use super::*;
+    use indy_vdr::ledger::RequestBuilder;
+
+    mod freeze_ledger {
+        use super::*;
+        use crate::utils::helpers::check_request_operation;
+
+        #[rstest]
+        fn test_freeze_ledger_request(request_builder: RequestBuilder, trustee_did: DidValue) {
+            let ledgers_ids = vec![0, 1, 50, 873];
+
+            let request = request_builder
+                .build_ledger_freeze_request(&trustee_did, &ledgers_ids)
+                .unwrap();
+
+            let expected_operation = json!({
+                "type": constants::LEDGERS_FREEZE,
+                "ledgers_ids": ledgers_ids
+            });
+            check_request_operation(&request, expected_operation);
+        }
+    }
+
+    mod get_frozen_ledgers {
+        use super::*;
+        use crate::utils::helpers::check_request_operation;
+
+        #[rstest]
+        fn test_get_frozen_ledgers_request(request_builder: RequestBuilder, trustee_did: DidValue) {
+            let request = request_builder
+                .build_get_frozen_ledgers_request(&trustee_did)
+                .unwrap();
+
+            let expected_operation = json!({
+                "type": constants::GET_FROZEN_LEDGERS,
+            });
+            check_request_operation(&request, expected_operation);
+        }
+    }
+}

--- a/libindy_vdr/tests/freeze_ledger.rs
+++ b/libindy_vdr/tests/freeze_ledger.rs
@@ -27,7 +27,7 @@ mod builder {
             let ledgers_ids = vec![0, 1, 50, 873];
 
             let request = request_builder
-                .build_ledger_freeze_request(&trustee_did, &ledgers_ids)
+                .build_ledgers_freeze_request(&trustee_did, &ledgers_ids)
                 .unwrap();
 
             let expected_operation = json!({

--- a/libindy_vdr/tests/pool_config.rs
+++ b/libindy_vdr/tests/pool_config.rs
@@ -51,7 +51,7 @@ mod send_pool_config {
         // Send Pool Config
         let mut request = pool
             .request_builder()
-            .build_pool_config(&trustee.did, false, false)
+            .build_pool_config_request(&trustee.did, false, false)
             .unwrap();
 
         let _response = helpers::sign_and_send_request(&trustee, &pool, &mut request).unwrap();
@@ -65,7 +65,7 @@ mod send_pool_config {
         // reset Pool Config
         let mut request = pool
             .request_builder()
-            .build_pool_config(&trustee.did, true, false)
+            .build_pool_config_request(&trustee.did, true, false)
             .unwrap();
 
         let _response = helpers::sign_and_send_request(&trustee, &pool, &mut request).unwrap();

--- a/libindy_vdr/tests/pool_config.rs
+++ b/libindy_vdr/tests/pool_config.rs
@@ -25,7 +25,7 @@ mod builder {
         #[rstest]
         fn test_pool_config_request(request_builder: RequestBuilder, trustee_did: DidValue) {
             let request = request_builder
-                .build_pool_config(&trustee_did, true, false)
+                .build_pool_config_request(&trustee_did, true, false)
                 .unwrap();
 
             let expected_operation = json!({

--- a/libindy_vdr/tests/pool_restart.rs
+++ b/libindy_vdr/tests/pool_restart.rs
@@ -90,7 +90,7 @@ mod send_pool_restart {
         // Start Pool Restart
         let mut request = pool
             .request_builder()
-            .build_pool_restart(&trustee.did, "start", Some(&_datetime()))
+            .build_pool_restart_request(&trustee.did, "start", Some(&_datetime()))
             .unwrap();
 
         let _response = helpers::sign_and_send_request(&trustee, &pool, &mut request).unwrap();
@@ -98,7 +98,7 @@ mod send_pool_restart {
         // Cancel Pool Restart
         let mut request = pool
             .request_builder()
-            .build_pool_restart(&trustee.did, "cancel", None)
+            .build_pool_restart_request(&trustee.did, "cancel", None)
             .unwrap();
 
         let _response = helpers::sign_and_send_request(&trustee, &pool, &mut request).unwrap();

--- a/libindy_vdr/tests/pool_restart.rs
+++ b/libindy_vdr/tests/pool_restart.rs
@@ -32,7 +32,7 @@ mod builder {
         #[rstest]
         fn test_build_pool_restart_request(request_builder: RequestBuilder, trustee_did: DidValue) {
             let request = request_builder
-                .build_pool_restart(&trustee_did, "start", None)
+                .build_pool_restart_request(&trustee_did, "start", None)
                 .unwrap();
 
             let expected_operation = json!({
@@ -48,7 +48,7 @@ mod builder {
             trustee_did: DidValue,
         ) {
             let request = request_builder
-                .build_pool_restart(&trustee_did, "cancel", None)
+                .build_pool_restart_request(&trustee_did, "cancel", None)
                 .unwrap();
 
             let expected_operation = json!({
@@ -64,7 +64,7 @@ mod builder {
             trustee_did: DidValue,
         ) {
             let request = request_builder
-                .build_pool_restart(&trustee_did, "start", Some(&_datetime()))
+                .build_pool_restart_request(&trustee_did, "start", Some(&_datetime()))
                 .unwrap();
 
             let expected_operation = json!({

--- a/libindy_vdr/tests/pool_upgrade.rs
+++ b/libindy_vdr/tests/pool_upgrade.rs
@@ -176,7 +176,7 @@ mod send_pool_upgrade {
         // Schedule Pool Upgrade
         let mut request = pool
             .request_builder()
-            .build_pool_upgrade(
+            .build_pool_upgrade_request(
                 &trustee.did,
                 NAME,
                 VERSION,
@@ -198,7 +198,7 @@ mod send_pool_upgrade {
         // Cancel Pool Upgrade
         let mut request = pool
             .request_builder()
-            .build_pool_upgrade(
+            .build_pool_upgrade_request(
                 &trustee.did,
                 NAME,
                 VERSION,

--- a/libindy_vdr/tests/pool_upgrade.rs
+++ b/libindy_vdr/tests/pool_upgrade.rs
@@ -65,7 +65,7 @@ mod builder {
             trustee_did: DidValue,
         ) {
             let request = request_builder
-                .build_pool_upgrade(
+                .build_pool_upgrade_request(
                     &trustee_did,
                     NAME,
                     VERSION,
@@ -99,7 +99,7 @@ mod builder {
             trustee_did: DidValue,
         ) {
             let request = request_builder
-                .build_pool_upgrade(
+                .build_pool_upgrade_request(
                     &trustee_did,
                     NAME,
                     VERSION,
@@ -133,7 +133,7 @@ mod builder {
             trustee_did: DidValue,
         ) {
             let request = request_builder
-                .build_pool_upgrade(
+                .build_pool_upgrade_request(
                     &trustee_did,
                     NAME,
                     VERSION,

--- a/wrappers/python/demo/test.py
+++ b/wrappers/python/demo/test.py
@@ -17,8 +17,8 @@ from indy_vdr.ledger import (
     build_get_revoc_reg_delta_request,
     build_get_schema_request,
     build_node_request,
-    build_pool_config,
-    build_pool_restart,
+    build_pool_config_request,
+    build_pool_restart_request,
     build_auth_rule_request,
     build_auth_rules_request,
     build_get_auth_rule_request,
@@ -133,31 +133,33 @@ async def basic_test(transactions_path):
         "client_port": 1,
         "alias": "some",
         "services": ["VALIDATOR"],
-        "blskey": "CnEDk9HrMnmiHXEV1WFgbVCRteYnPqsJwrTdcZaNhFVW"
+        "blskey": "CnEDk9HrMnmiHXEV1WFgbVCRteYnPqsJwrTdcZaNhFVW",
     }
     req = build_node_request(identifier, dest, data)
     log("Node request:", req.body)
 
-    req = build_pool_config(identifier, True, False)
+    req = build_pool_config_request(identifier, True, False)
     log("Pool Config request:", req.body)
 
-    req = build_pool_restart(identifier, "start", None)
+    req = build_pool_restart_request(identifier, "start", None)
     log("Pool Restart request:", req.body)
 
     txn_type = "NYM"
     auth_type = "1"
     auth_action = "ADD"
-    field = 'role'
-    old_value = '0'
-    new_value = '101'
+    field = "role"
+    old_value = "0"
+    new_value = "101"
     constraint = {
         "sig_count": 1,
         "metadata": {},
         "role": "0",
         "constraint_id": "ROLE",
-        "need_to_be_owner": False
+        "need_to_be_owner": False,
     }
-    req = build_auth_rule_request(identifier, txn_type, auth_action, field, old_value, new_value, constraint)
+    req = build_auth_rule_request(
+        identifier, txn_type, auth_action, field, old_value, new_value, constraint
+    )
     log("Auth Rule request:", req.body)
 
     rules = [
@@ -166,13 +168,15 @@ async def basic_test(transactions_path):
             "auth_action": auth_action,
             "field": field,
             "new_value": new_value,
-            "constraint": constraint
+            "constraint": constraint,
         },
     ]
     req = build_auth_rules_request(identifier, rules)
     log("Auth Rules request:", req.body)
 
-    req = build_get_auth_rule_request(identifier, auth_type, auth_action, field, None, new_value)
+    req = build_get_auth_rule_request(
+        identifier, auth_type, auth_action, field, None, new_value
+    )
     log("Get Auth Rule request:", req.body)
 
     ledgers_ids = [1, 10, 100]

--- a/wrappers/python/demo/test.py
+++ b/wrappers/python/demo/test.py
@@ -16,6 +16,14 @@ from indy_vdr.ledger import (
     build_get_revoc_reg_request,
     build_get_revoc_reg_delta_request,
     build_get_schema_request,
+    build_node_request,
+    build_pool_config,
+    build_pool_restart,
+    build_auth_rule_request,
+    build_auth_rules_request,
+    build_get_auth_rule_request,
+    build_ledgers_freeze_request,
+    build_get_frozen_ledgers_request,
     # build_revoc_reg_entry_request,
     # build_rich_schema_request,
     # build_get_schema_object_by_id_request,
@@ -115,6 +123,64 @@ async def basic_test(transactions_path):
 
     req = build_get_revoc_reg_delta_request(None, revoc_id, from_ts=None, to_ts=1)
     log("Get revoc reg delta request:", req.body)
+
+    identifier = "V4SGRU86Z58d6TV7PBUe6f"
+    dest = "V4SGRU86Z58d6TV7PBUe6f"
+    data = {
+        "node_ip": "ip",
+        "node_port": 1,
+        "client_ip": "ip",
+        "client_port": 1,
+        "alias": "some",
+        "services": ["VALIDATOR"],
+        "blskey": "CnEDk9HrMnmiHXEV1WFgbVCRteYnPqsJwrTdcZaNhFVW"
+    }
+    req = build_node_request(identifier, dest, data)
+    log("Node request:", req.body)
+
+    req = build_pool_config(identifier, True, False)
+    log("Pool Config request:", req.body)
+
+    req = build_pool_restart(identifier, "start", None)
+    log("Pool Restart request:", req.body)
+
+    txn_type = "NYM"
+    auth_type = "1"
+    auth_action = "ADD"
+    field = 'role'
+    old_value = '0'
+    new_value = '101'
+    constraint = {
+        "sig_count": 1,
+        "metadata": {},
+        "role": "0",
+        "constraint_id": "ROLE",
+        "need_to_be_owner": False
+    }
+    req = build_auth_rule_request(identifier, txn_type, auth_action, field, old_value, new_value, constraint)
+    log("Auth Rule request:", req.body)
+
+    rules = [
+        {
+            "auth_type": auth_type,
+            "auth_action": auth_action,
+            "field": field,
+            "new_value": new_value,
+            "constraint": constraint
+        },
+    ]
+    req = build_auth_rules_request(identifier, rules)
+    log("Auth Rules request:", req.body)
+
+    req = build_get_auth_rule_request(identifier, auth_type, auth_action, field, None, new_value)
+    log("Get Auth Rule request:", req.body)
+
+    ledgers_ids = [1, 10, 100]
+    req = build_ledgers_freeze_request(identifier, ledgers_ids)
+    log("Ledgers Freeze request:", req.body)
+
+    req = build_get_frozen_ledgers_request(identifier)
+    log("Get Frozen Ledgers request:", req.body)
 
     # req = build_rich_schema_request(
     #     None, "did:sov:some_hash", '{"some": 1}', "test", "version", "sch", "1.0.0"

--- a/wrappers/python/indy_vdr/ledger.py
+++ b/wrappers/python/indy_vdr/ledger.py
@@ -1,6 +1,6 @@
 """Methods for generating and working with pool ledger requests."""
 
-from ctypes import byref, c_int32, c_int64, c_uint64, c_bool
+from ctypes import byref, c_int8, c_int32, c_int64, c_uint64
 from datetime import datetime, date
 from enum import IntEnum
 from typing import Optional, Union
@@ -806,9 +806,6 @@ def build_get_rich_schema_object_by_id_request(
     did_p = encode_str(submitter_did)
     rs_id = encode_str(rs_id) if isinstance(rs_id, (str, bytes)) else encode_json(rs_id)
     do_call(
-        "indy_vdr_build_get_schema_object_by_id_request", did_p, rs_id, byref(handle)
-    )
-    do_call(
         "indy_vdr_build_get_rich_schema_object_by_id_request",
         did_p,
         rs_id,
@@ -840,14 +837,6 @@ def build_get_rich_schema_object_by_metadata_request(
     rs_type = encode_str(rs_type)
     rs_name = encode_str(rs_name)
     rs_version = encode_str(rs_version)
-    do_call(
-        "indy_vdr_build_get_schema_object_by_metadata_request",
-        did_p,
-        rs_type,
-        rs_name,
-        rs_version,
-        byref(handle),
-    )
     do_call(
         "indy_vdr_build_get_rich_schema_object_by_metadata_request",
         did_p,
@@ -888,9 +877,7 @@ def build_node_request(
     handle = RequestHandle()
     identifier_p = encode_str(identifier)
     dest_p = encode_str(dest)
-    data_p = (
-        encode_str(data) if isinstance(data, (str, bytes)) else encode_json(data)
-    )
+    data_p = encode_str(data) if isinstance(data, (str, bytes)) else encode_json(data)
     do_call(
         "indy_vdr_build_node_request",
         identifier_p,
@@ -901,7 +888,7 @@ def build_node_request(
     return Request(handle)
 
 
-def build_pool_config(
+def build_pool_config_request(
     identifier: str,
     writes: bool,
     force: bool,
@@ -921,8 +908,8 @@ def build_pool_config(
     """
     handle = RequestHandle()
     identifier_p = encode_str(identifier)
-    c_writes = c_bool(writes)
-    c_force = c_bool(force)
+    c_writes = c_int8(writes)
+    c_force = c_int8(force)
     do_call(
         "indy_vdr_build_pool_config_request",
         identifier_p,
@@ -933,7 +920,7 @@ def build_pool_config(
     return Request(handle)
 
 
-def build_pool_restart(
+def build_pool_restart_request(
     identifier: str,
     action: str,
     datetime: Optional[str],
@@ -1014,7 +1001,9 @@ def build_auth_rule_request(
     old_value_p = encode_str(old_value)
     new_value_p = encode_str(new_value)
     constraint_p = (
-        encode_str(constraint) if isinstance(constraint, (str, bytes)) else encode_json(constraint)
+        encode_str(constraint)
+        if isinstance(constraint, (str, bytes))
+        else encode_json(constraint)
     )
     do_call(
         "indy_vdr_build_auth_rule_request",
@@ -1128,12 +1117,14 @@ def build_ledgers_freeze_request(
     Args:
         identifier: Identifier (DID) of the transaction author as base58-encoded
             string.
-	    ledgers_ids: List of ledgers IDs for freezing.
+            ledgers_ids: List of ledgers IDs for freezing.
     """
     handle = RequestHandle()
     identifier_p = encode_str(identifier)
     ledgers_ids_p = (
-        encode_str(ledgers_ids) if isinstance(ledgers_ids, (str, bytes)) else encode_json(ledgers_ids)
+        encode_str(ledgers_ids)
+        if isinstance(ledgers_ids, (str, bytes))
+        else encode_json(ledgers_ids)
     )
     do_call(
         "indy_vdr_build_ledgers_freeze_request",
@@ -1150,8 +1141,8 @@ def build_get_frozen_ledgers_request(
     """
     Builds an GET_FROZEN_LEDGERS request.
 
-	Request to get list of frozen ledgers.
-	Frozen ledgers are defined by ledgers freeze request.
+        Request to get list of frozen ledgers.
+        Frozen ledgers are defined by ledgers freeze request.
 
     Args:
         identifier: Identifier (DID) of the transaction author as base58-encoded

--- a/wrappers/python/indy_vdr/ledger.py
+++ b/wrappers/python/indy_vdr/ledger.py
@@ -1,6 +1,6 @@
 """Methods for generating and working with pool ledger requests."""
 
-from ctypes import byref, c_int32, c_int64, c_uint64
+from ctypes import byref, c_int32, c_int64, c_uint64, c_bool
 from datetime import datetime, date
 from enum import IntEnum
 from typing import Optional, Union
@@ -854,6 +854,314 @@ def build_get_rich_schema_object_by_metadata_request(
         rs_type,
         rs_name,
         rs_version,
+        byref(handle),
+    )
+    return Request(handle)
+
+
+def build_node_request(
+    identifier: str,
+    dest: str,
+    data: Union[bytes, str, dict],
+) -> str:
+    """
+    Builds an NODE request.
+
+    Request to add a new node to the pool, or updates existing in the pool.
+
+    Args:
+        identifier: Identifier (DID) of the transaction author as base58-encoded
+            string.
+        dest: Target DID as base58-encoded string for 16 or 32 bit DID value.
+        data: Data associated with the Node:
+          {
+              alias: string - Node's alias
+              blskey: string - (Optional) BLS multi-signature key as base58-encoded string.
+              blskey_pop: string - (Optional) BLS key proof of possession as base58-encoded string.
+              client_ip: string - (Optional) Node's client listener IP address.
+              client_port: string - (Optional) Node's client listener port.
+              node_ip: string - (Optional) The IP address other Nodes use to communicate with this Node.
+              node_port: string - (Optional) The port other Nodes use to communicate with this Node.
+              services: array<string> - (Optional) The service of the Node. VALIDATOR is the only supported one now.
+          }
+    """
+    handle = RequestHandle()
+    identifier_p = encode_str(identifier)
+    dest_p = encode_str(dest)
+    data_p = (
+        encode_str(data) if isinstance(data, (str, bytes)) else encode_json(data)
+    )
+    do_call(
+        "indy_vdr_build_node_request",
+        identifier_p,
+        dest_p,
+        data_p,
+        byref(handle),
+    )
+    return Request(handle)
+
+
+def build_pool_config(
+    identifier: str,
+    writes: bool,
+    force: bool,
+) -> str:
+    """
+    Builds an POOL_CONFIG request.
+
+    Request to change Pool's configuration.
+
+    Args:
+        identifier: Identifier (DID) of the transaction author as base58-encoded
+            string.
+        writes: Whether any write requests can be processed by the pool
+                   (if false, then pool goes to read-only state). True by default.
+        force: Whether we should apply transaction (for example, move pool to read-only state)
+                  without waiting for consensus of this transaction
+    """
+    handle = RequestHandle()
+    identifier_p = encode_str(identifier)
+    c_writes = c_bool(writes)
+    c_force = c_bool(force)
+    do_call(
+        "indy_vdr_build_pool_config",
+        identifier_p,
+        c_writes,
+        c_force,
+        byref(handle),
+    )
+    return Request(handle)
+
+
+def build_pool_restart(
+    identifier: str,
+    action: str,
+    datetime: Optional[str],
+) -> str:
+    """
+    Builds an POOL_RESTART request.
+
+    Request to restart Pool.
+
+    Args:
+        identifier: Identifier (DID) of the transaction author as base58-encoded
+            string.
+        action: Action that pool has to do after received transaction.
+                Can be "start" or "cancel"
+        datetime: (Optional) Time when pool must be restarted.
+    """
+    handle = RequestHandle()
+    identifier_p = encode_str(identifier)
+    action_p = encode_str(action)
+    datetime_p = encode_str(datetime)
+    do_call(
+        "indy_vdr_build_pool_restart",
+        identifier_p,
+        action_p,
+        datetime_p,
+        byref(handle),
+    )
+    return Request(handle)
+
+
+def build_auth_rule_request(
+    submitter_did: str,
+    txn_type: str,
+    action: str,
+    field: str,
+    old_value: Optional[str],
+    new_value: Optional[str],
+    constraint: Union[bytes, str, dict],
+) -> str:
+    """
+    Builds an AUTH_RULE request.
+
+    Request to change authentication rules for a ledger transaction.
+
+    Args:
+        submitter_did: Identifier (DID) of the transaction author as base58-encoded
+            string.
+        txn_type: ledger transaction alias or associated value.
+        action: type of an action.
+           Can be either "ADD" (to add a new rule) or "EDIT" (to edit an existing one).
+        field: transaction field.
+        old_value: (Optional) old value of a field, which can be changed to a new_value (mandatory for EDIT action).
+        new_value: (Optional) new value that can be used to fill the field.
+        constraint: set of constraints required for execution of an action in the following format:
+            {
+                constraint_id - <string> type of a constraint.
+                    Can be either "ROLE" to specify final constraint or  "AND"/"OR" to combine constraints.
+                role - <string> (optional) role of a user which satisfy to constrain.
+                sig_count - <u32> the number of signatures required to execution action.
+                need_to_be_owner - <bool> (optional) if user must be an owner of transaction (false by default).
+                off_ledger_signature - <bool> (optional) allow signature of unknow for ledger did (false by default).
+                metadata - <object> (optional) additional parameters of the constraint.
+            }
+        can be combined by
+            {
+                'constraint_id': <"AND" or "OR">
+                'auth_constraints': [<constraint_1>, <constraint_2>]
+            }
+
+        Default ledger auth rules: https://github.com/hyperledger/indy-node/blob/master/docs/source/auth_rules.md
+        More about AUTH_RULE request: https://github.com/hyperledger/indy-node/blob/master/docs/source/requests.md#auth_rule
+    """
+    handle = RequestHandle()
+    submitter_did_p = encode_str(submitter_did)
+    txn_type_p = encode_str(txn_type)
+    action_p = encode_str(action)
+    field_p = encode_str(field)
+    old_value_p = encode_str(old_value)
+    new_value_p = encode_str(new_value)
+    constraint_p = (
+        encode_str(constraint) if isinstance(constraint, (str, bytes)) else encode_json(constraint)
+    )
+    do_call(
+        "indy_vdr_build_auth_rule_request",
+        submitter_did_p,
+        txn_type_p,
+        action_p,
+        field_p,
+        old_value_p,
+        new_value_p,
+        constraint_p,
+        byref(handle),
+    )
+    return Request(handle)
+
+
+def build_auth_rules_request(
+    submitter_did: str,
+    rules: Union[bytes, str, dict],
+) -> str:
+    """
+    Builds an AUTH_RULES request.
+
+    Request to change multiple authentication rules for a ledger transaction.
+
+    Args:
+        submitter_did: Identifier (DID) of the transaction author as base58-encoded
+            string.
+        data: a list of auth rules: [
+            {
+                "auth_type": ledger transaction alias or associated value,
+                "auth_action": type of an action,
+                "field": transaction field,
+                "old_value": (Optional) old value of a field, which can be changed to a new_value (mandatory for EDIT action),
+                "new_value": (Optional) new value that can be used to fill the field,
+                "constraint": set of constraints required for execution of an action in the format described above for `build_auth_rule_request` function.
+            }
+        ]
+
+        Default ledger auth rules: https://github.com/hyperledger/indy-node/blob/master/docs/source/auth_rules.md
+        More about AUTH_RULE request: https://github.com/hyperledger/indy-node/blob/master/docs/source/requests.md#auth_rules
+    """
+    handle = RequestHandle()
+    submitter_did_p = encode_str(submitter_did)
+    rules_p = (
+        encode_str(rules) if isinstance(rules, (str, bytes)) else encode_json(rules)
+    )
+    do_call(
+        "indy_vdr_build_auth_rules_request",
+        submitter_did_p,
+        rules_p,
+        byref(handle),
+    )
+    return Request(handle)
+
+
+def build_get_auth_rule_request(
+    submitter_did: Optional[str],
+    auth_type: Optional[str],
+    auth_action: Optional[str],
+    field: Optional[str],
+    old_value: Optional[str],
+    new_value: Optional[str],
+) -> str:
+    """
+    Builds an GET_AUTH_RULE request.
+
+    Request to get authentication rules for a ledger transaction.
+
+    NOTE: Either none or all transaction related parameters must be specified (`old_value` can be skipped for `ADD` action).
+        * none - to get all authentication rules for all ledger transactions
+        * all - to get authentication rules for specific action (`old_value` can be skipped for `ADD` action)
+
+    Args:
+        submitter_did: Identifier (DID) of the transaction author as base58-encoded
+            string.
+        auth_type: target ledger transaction alias or associated value.
+        auth_action: target action type. Can be either "ADD" or "EDIT".
+        field: target transaction field.
+        old_value: (Optional) old value of field, which can be changed to a new_value (must be specified for EDIT action).
+        new_value: (Optional) new value that can be used to fill the field.
+    """
+    handle = RequestHandle()
+    submitter_did_p = encode_str(submitter_did)
+    auth_type_p = encode_str(auth_type)
+    auth_action_p = encode_str(auth_action)
+    field_p = encode_str(field)
+    old_value_p = encode_str(old_value)
+    new_value_p = encode_str(new_value)
+    do_call(
+        "indy_vdr_build_get_auth_rule_request",
+        submitter_did_p,
+        auth_type_p,
+        auth_action_p,
+        field_p,
+        old_value_p,
+        new_value_p,
+        byref(handle),
+    )
+    return Request(handle)
+
+
+def build_ledgers_freeze_request(
+    identifier: str,
+    ledgers_ids: Union[bytes, str, dict],
+) -> str:
+    """
+    Builds an LEDGERS_FREEZE request.
+
+    Request to freeze list of ledgers.
+
+    Args:
+        identifier: Identifier (DID) of the transaction author as base58-encoded
+            string.
+	    ledgers_ids: List of ledgers IDs for freezing.
+    """
+    handle = RequestHandle()
+    identifier_p = encode_str(identifier)
+    ledgers_ids_p = (
+        encode_str(ledgers_ids) if isinstance(ledgers_ids, (str, bytes)) else encode_json(ledgers_ids)
+    )
+    do_call(
+        "indy_vdr_build_ledgers_freeze_request",
+        identifier_p,
+        ledgers_ids_p,
+        byref(handle),
+    )
+    return Request(handle)
+
+
+def build_get_frozen_ledgers_request(
+    identifier: str,
+) -> str:
+    """
+    Builds an GET_FROZEN_LEDGERS request.
+
+	Request to get list of frozen ledgers.
+	Frozen ledgers are defined by ledgers freeze request.
+
+    Args:
+        identifier: Identifier (DID) of the transaction author as base58-encoded
+            string.
+    """
+    handle = RequestHandle()
+    identifier_p = encode_str(identifier)
+    do_call(
+        "indy_vdr_build_get_frozen_ledgers_request",
+        identifier_p,
         byref(handle),
     )
     return Request(handle)

--- a/wrappers/python/indy_vdr/ledger.py
+++ b/wrappers/python/indy_vdr/ledger.py
@@ -924,7 +924,7 @@ def build_pool_config(
     c_writes = c_bool(writes)
     c_force = c_bool(force)
     do_call(
-        "indy_vdr_build_pool_config",
+        "indy_vdr_build_pool_config_request",
         identifier_p,
         c_writes,
         c_force,
@@ -955,7 +955,7 @@ def build_pool_restart(
     action_p = encode_str(action)
     datetime_p = encode_str(datetime)
     do_call(
-        "indy_vdr_build_pool_restart",
+        "indy_vdr_build_pool_restart_request",
         identifier_p,
         action_p,
         datetime_p,


### PR DESCRIPTION
Here is the list of added functions:
```
build_node_request
build_pool_config
build_pool_restart
build_auth_rule_request
build_auth_rules_request
build_get_auth_rule_request
build_ledgers_freeze_request
build_get_frozen_ledgers_request 
```

These methods are needed for upgrading the Indy Test Automation repository to use Indy VDR for testing Indy Plenum and Indy Node instead of libindy.

This PR includes and depends on the changes from the PR https://github.com/hyperledger/indy-vdr/pull/134