### PR TITLE
Corrected builder for NYM request in Python wrapper

### DIFF
--- a/wrappers/python/indy_vdr/ledger.py
+++ b/wrappers/python/indy_vdr/ledger.py
@@ -493,9 +493,9 @@ def build_nym_request(
     handle = RequestHandle()
     did_p = encode_str(submitter_did)
     dest_p = encode_str(dest)
-    verkey_p = encode_str(verkey) if verkey else None
-    alias_p = encode_str(alias) if alias else None
-    role_p = encode_str(role) if role else None
+    verkey_p = encode_str(verkey)
+    alias_p = encode_str(alias)
+    role_p = encode_str(role)
     do_call(
         "indy_vdr_build_nym_request",
         did_p,


### PR DESCRIPTION
Issue: Empty string (`""`) should be passed into Rust as is.  The previous condition passed `null` instead of empty string.
```
build_nym_request(did, did, None, None, "") - generated wrong request 
```
