### PR TITLE
fix(js): return body as string to

### DIFF
--- a/wrappers/javascript/indy-vdr-nodejs/src/NodeJSIndyVdr.ts
+++ b/wrappers/javascript/indy-vdr-nodejs/src/NodeJSIndyVdr.ts
@@ -511,14 +511,13 @@ export class NodeJSIndyVdr implements IndyVdr {
     this.handleError(this.nativeIndyVdr.indy_vdr_request_free(requestHandle))
   }
 
-  public requestGetBody<T extends Record<string, unknown>>(options: { requestHandle: number }): T {
+  public requestGetBody(options: { requestHandle: number }): string {
     const output = allocateString()
     const { requestHandle } = serializeArguments(options)
 
     this.handleError(this.nativeIndyVdr.indy_vdr_request_get_body(requestHandle, output))
 
-    const outputString = handleReturnPointer<string>(output)
-    return JSON.parse(outputString) as T
+    return handleReturnPointer<string>(output)
   }
 
   public requestGetSignatureInput(options: { requestHandle: number }): string {

--- a/wrappers/javascript/indy-vdr-nodejs/tests/CustomRequest.test.ts
+++ b/wrappers/javascript/indy-vdr-nodejs/tests/CustomRequest.test.ts
@@ -1,8 +1,8 @@
 import type { IndyVdrPool } from '@hyperledger/indy-vdr-nodejs'
 
-import { DID, setupPool } from './utils'
-
 import { CustomRequest } from '@hyperledger/indy-vdr-nodejs'
+
+import { DID, setupPool } from './utils'
 
 describe('CustomRequest', () => {
   let pool: IndyVdrPool
@@ -22,5 +22,21 @@ describe('CustomRequest', () => {
     await expect(pool.submitRequest(request)).resolves.toMatchObject({
       op: 'REPLY',
     })
+  })
+
+  test('Can parse a request from string', async () => {
+    const json = `{"endorser":"DJKobikPAaYWAu9vfhEEo5","identifier":"2GjxcxqE2XnFrVhipkWCWT","operation":{"dest":"2GjxcxqE2XnFrVhipkWCWT","raw":"{\\"endpoint\\":{\\"endpoint\\":\\"https://example.com/endpoint\\",\\"routingKeys\\":[\\"a-routing-key\\"],\\"types\\":[\\"endpoint\\",\\"did-communication\\",\\"DIDComm\\"]}}","type":"100"},"protocolVersion":2,"reqId":1680599092494999800,"signature":"3RyENWHC1szYH7FwDfZ2pKteShtsuDgYCSjGQGDPDjAYE5mipCZ6AnZKuAgCQYq6yt1LEfPPRKVS8BjBirX5s5q3","taaAcceptance":{"mechanism":"accept","taaDigest":"e546ad2a5311b2020fd80efb4d17ec75f823d26ee2424cf741ee345ede9d3ff3","time":1680566400}}`
+    const request = new CustomRequest({
+      customRequest: json,
+    })
+
+    request.setMultiSignature({
+      identifier: 'TL1EaPFCZ8Si5aUrqScBDt',
+      signature: Buffer.from('Hello, this is a signature'),
+    })
+
+    expect(request.body).toEqual(
+      '{"endorser":"DJKobikPAaYWAu9vfhEEo5","identifier":"2GjxcxqE2XnFrVhipkWCWT","operation":{"dest":"2GjxcxqE2XnFrVhipkWCWT","raw":"{\\"endpoint\\":{\\"endpoint\\":\\"https://example.com/endpoint\\",\\"routingKeys\\":[\\"a-routing-key\\"],\\"types\\":[\\"endpoint\\",\\"did-communication\\",\\"DIDComm\\"]}}","type":"100"},"protocolVersion":2,"reqId":1680599092494999800,"signatures":{"2GjxcxqE2XnFrVhipkWCWT":"3RyENWHC1szYH7FwDfZ2pKteShtsuDgYCSjGQGDPDjAYE5mipCZ6AnZKuAgCQYq6yt1LEfPPRKVS8BjBirX5s5q3","TL1EaPFCZ8Si5aUrqScBDt":"3DaTn63KBMjCE8pCLkDvMBFPKHefZiQXyzr8"},"taaAcceptance":{"mechanism":"accept","taaDigest":"e546ad2a5311b2020fd80efb4d17ec75f823d26ee2424cf741ee345ede9d3ff3","time":1680566400}}'
+    )
   })
 })

--- a/wrappers/javascript/indy-vdr-react-native/src/ReactNativeIndyVdr.ts
+++ b/wrappers/javascript/indy-vdr-react-native/src/ReactNativeIndyVdr.ts
@@ -303,10 +303,9 @@ export class ReactNativeIndyVdr implements IndyVdr {
     indyVdrReactNative.requestFree(serializedOptions)
   }
 
-  public requestGetBody<T extends Record<string, unknown>>(options: { requestHandle: number }): T {
+  public requestGetBody(options: { requestHandle: number }): string {
     const serializedOptions = serializeArguments(options)
-    const result = handleError(indyVdrReactNative.requestGetBody(serializedOptions))
-    return JSON.parse(result) as T
+    return handleError(indyVdrReactNative.requestGetBody(serializedOptions))
   }
 
   public requestGetSignatureInput(options: { requestHandle: number }): string {

--- a/wrappers/javascript/indy-vdr-shared/src/builder/CustomRequest.ts
+++ b/wrappers/javascript/indy-vdr-shared/src/builder/CustomRequest.ts
@@ -1,13 +1,7 @@
 import { indyVdr, IndyVdrRequest } from '../indyVdr'
 
-// TODO: this needs some more work, but need to find a way to use it first.
 export type CustomRequestOptions = {
-  customRequest: {
-    protocolVersion: 1 | 2
-    reqId?: number
-    identifier: string
-    operation: Record<string, unknown>
-  }
+  customRequest: string | Record<string, unknown>
 }
 
 export class CustomRequest extends IndyVdrRequest {

--- a/wrappers/javascript/indy-vdr-shared/src/indyVdr/IndyVdrRequest.ts
+++ b/wrappers/javascript/indy-vdr-shared/src/indyVdr/IndyVdrRequest.ts
@@ -36,7 +36,7 @@ export class IndyVdrRequest<ResponseType extends Record<string, unknown> = Recor
     return this._handle
   }
 
-  public get body(): Record<string, unknown> {
+  public get body(): string {
     return indyVdr.requestGetBody({ requestHandle: this.handle })
   }
 

--- a/wrappers/javascript/indy-vdr-shared/src/types/IndyVdr.ts
+++ b/wrappers/javascript/indy-vdr-shared/src/types/IndyVdr.ts
@@ -115,7 +115,7 @@ export interface IndyVdr {
 
   requestFree(options: { requestHandle: number }): void
 
-  requestGetBody<T extends Record<string, unknown>>(options: { requestHandle: number }): T
+  requestGetBody(options: { requestHandle: number }): string
 
   requestGetSignatureInput(options: { requestHandle: number }): string
 


### PR DESCRIPTION
This is to prevent the reqId (which is a large number) from overflowing and changing

We were running into this when implementing endorsement and needing to get the body of a request and send it to another agent. ACA-Py / the python wrapper als returns a string representation of the request when calling body