### PR TITLE
Issue #210 InvalidClientTaaAcceptanceError time too precise error if container timezone is not UTC

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -358,8 +358,7 @@ jobs:
   build-android:
     name: Build library (Android)
     needs: [checks]
-    env:
-      RUST_VERSION: "1.64.0" # Overriding the rust version here for lower NDK support
+    # NB: RUST_VERSION must be <1.68 here to support NDK 17
 
     runs-on: ubuntu-latest
     strategy:

--- a/indy-vdr-proxy/Cargo.toml
+++ b/indy-vdr-proxy/Cargo.toml
@@ -16,7 +16,7 @@ tls = ["rustls-pemfile", "tokio-rustls", "hyper/stream"]
 default = ["fetch", "zmq_vendored"]
 
 [dependencies]
-clap = "4.3"
+clap = "~4.2"
 env_logger = "0.10"
 futures-executor = "0.3"
 futures-util = "0.3"

--- a/wrappers/python/indy_vdr/ledger.py
+++ b/wrappers/python/indy_vdr/ledger.py
@@ -761,7 +761,9 @@ def prepare_txn_author_agreement_acceptance(
     if not accepted_time:
         # rough timestamp
         accepted_time = int(
-            datetime.combine(date.today(), datetime.min.time(), tzinfo=timezone.utc).timestamp()
+            datetime.combine(
+                date.today(), datetime.min.time(), timezone.utc
+            ).timestamp()
         )
     result = lib_string()
     do_call(

--- a/wrappers/python/indy_vdr/ledger.py
+++ b/wrappers/python/indy_vdr/ledger.py
@@ -1,5 +1,6 @@
 """Methods for generating and working with pool ledger requests."""
 
+import pytz as timezone
 from ctypes import byref, c_int8, c_int32, c_int64, c_uint64
 from datetime import datetime, date
 from enum import IntEnum
@@ -760,7 +761,7 @@ def prepare_txn_author_agreement_acceptance(
     if not accepted_time:
         # rough timestamp
         accepted_time = int(
-            datetime.combine(date.today(), datetime.min.time()).timestamp()
+            datetime.combine(date.today(), datetime.min.time(), tzinfo=timezone.utc).timestamp()
         )
     result = lib_string()
     do_call(

--- a/wrappers/python/indy_vdr/ledger.py
+++ b/wrappers/python/indy_vdr/ledger.py
@@ -1,6 +1,5 @@
 """Methods for generating and working with pool ledger requests."""
 
-import pytz as timezone
 from ctypes import byref, c_int8, c_int32, c_int64, c_uint64
 from datetime import datetime, date
 from enum import IntEnum
@@ -762,7 +761,7 @@ def prepare_txn_author_agreement_acceptance(
         # rough timestamp
         accepted_time = int(
             datetime.combine(
-                date.today(), datetime.min.time(), timezone.utc
+                date.today(), datetime.min.time(), datetime.timezone.utc
             ).timestamp()
         )
     result = lib_string()

--- a/wrappers/python/indy_vdr/ledger.py
+++ b/wrappers/python/indy_vdr/ledger.py
@@ -1,7 +1,7 @@
 """Methods for generating and working with pool ledger requests."""
 
 from ctypes import byref, c_int8, c_int32, c_int64, c_uint64
-from datetime import datetime, date
+from datetime import datetime, date, timezone
 from enum import IntEnum
 from typing import Optional, Union
 

--- a/wrappers/python/indy_vdr/ledger.py
+++ b/wrappers/python/indy_vdr/ledger.py
@@ -1,7 +1,7 @@
 """Methods for generating and working with pool ledger requests."""
 
 from ctypes import byref, c_int8, c_int32, c_int64, c_uint64
-from datetime import datetime, date
+from datetime import datetime, date, timezone
 from enum import IntEnum
 from typing import Optional, Union
 
@@ -761,7 +761,7 @@ def prepare_txn_author_agreement_acceptance(
         # rough timestamp
         accepted_time = int(
             datetime.combine(
-                date.today(), datetime.min.time(), datetime.timezone.utc
+                date.today(), datetime.min.time(), timezone.utc
             ).timestamp()
         )
     result = lib_string()

--- a/wrappers/python/indy_vdr/ledger.py
+++ b/wrappers/python/indy_vdr/ledger.py
@@ -1,7 +1,7 @@
 """Methods for generating and working with pool ledger requests."""
 
 from ctypes import byref, c_int8, c_int32, c_int64, c_uint64
-from datetime import datetime, date, timezone
+from datetime import datetime, date
 from enum import IntEnum
 from typing import Optional, Union
 


### PR DESCRIPTION
Adds timezone.utc to datetime.combine to ensure time will be midnight in UTC regardless of the default timezone