### PR TITLE
Update to indy-data-types 0.7; remove indy-utils

### DIFF
--- a/indy-vdr-proxy/Cargo.toml
+++ b/indy-vdr-proxy/Cargo.toml
@@ -23,7 +23,7 @@ futures-util = "0.3"
 indy-vdr = { path = "../libindy_vdr", default-features = false, features = [
     "log",
 ] }
-git2 = "0.17"
+git2 = "0.18"
 hyper = { version = "0.14", features = ["http1", "http2", "server"] }
 hyper-tls = { version = "0.5", optional = true }
 log = "0.4.8"

--- a/indy-vdr-proxy/src/main.rs
+++ b/indy-vdr-proxy/src/main.rs
@@ -369,7 +369,7 @@ async fn init_server(config: app::Config) -> Result<(), String> {
     #[cfg(feature = "tls")]
     if let (Some(tls_cert_path), Some(tls_key_path)) = (&config.tls_cert_path, &config.tls_key_path)
     {
-        let tls_cfg = build_tls_config(&tls_cert_path, &tls_key_path)?;
+        let tls_cfg = build_tls_config(tls_cert_path, tls_key_path)?;
         let tls_acceptor = TlsAcceptor::from(Arc::new(tls_cfg));
         let tcp_listener = TcpListener::bind(&addr)
             .await
@@ -420,7 +420,7 @@ fn build_tls_config(cert_path: &str, key_path: &str) -> Result<ServerConfig, Str
                     .ok_or_else(|| "Error parsing TLS key file: no keys found".to_string())?,
             ),
         )
-        .map_err(|err| format!("Error building TLS config: {}", err.to_string()))
+        .map_err(|err| format!("Error building TLS config: {}", err))
 }
 
 async fn run_server<I>(

--- a/libindy_vdr/Cargo.toml
+++ b/libindy_vdr/Cargo.toml
@@ -40,12 +40,10 @@ futures-executor = "0.3"
 futures-util = "0.3"
 hex = "0.4"
 indy-blssignatures = "0.1"
-indy-data-types = { version = "0.6.1", default-features = false, features = [
+indy-data-types = { version = "0.7", default-features = false, features = [
     "anoncreds",
-    "merkle_tree",
-] }
-indy-utils = { version = "0.6", default-features = false, features = [
     "ed25519",
+    "merkle_tree",
 ] }
 once_cell = "1.5"
 log = { version = "0.4", optional = true }
@@ -66,6 +64,6 @@ zmq = "0.9"
 [dev-dependencies]
 rstest = "0.18"
 time = "0.3"
-indy-data-types = { version = "0.6.1", default-features = false, features = [
+indy-data-types = { version = "0.7", default-features = false, features = [
     "rich_schema",
 ] }

--- a/libindy_vdr/src/common/handle.rs
+++ b/libindy_vdr/src/common/handle.rs
@@ -6,7 +6,6 @@ pub trait ResourceHandle: Copy + Ord + From<i64> {
     fn next() -> Self;
 }
 
-#[cfg(feature = "ffi")]
 /// Derive a new handle type having an atomically increasing sequence number
 macro_rules! impl_sequence_handle (($newtype:ident, $counter:ident) => (
     static $counter: std::sync::atomic::AtomicI64 = std::sync::atomic::AtomicI64::new(0);

--- a/libindy_vdr/src/lib.rs
+++ b/libindy_vdr/src/lib.rs
@@ -48,7 +48,7 @@ extern crate serde;
 extern crate serde_json;
 
 #[macro_use]
-extern crate indy_utils;
+extern crate indy_data_types;
 
 /// Utility functions, traits and macros
 #[macro_use]

--- a/libindy_vdr/src/pool/manager.rs
+++ b/libindy_vdr/src/pool/manager.rs
@@ -17,6 +17,7 @@ use super::requests::{PoolRequest, PoolRequestImpl};
 use super::types::{PoolSetup, RequestHandle, Verifiers};
 
 use crate::common::error::prelude::*;
+use crate::common::handle::ResourceHandle;
 use crate::common::merkle_tree::MerkleTree;
 use crate::config::PoolConfig;
 use crate::ledger::RequestBuilder;

--- a/libindy_vdr/src/pool/networker/zmq.rs
+++ b/libindy_vdr/src/pool/networker/zmq.rs
@@ -10,15 +10,24 @@ use zmq::PollItem;
 use zmq::Socket as ZSocket;
 
 use crate::common::error::prelude::*;
+use crate::common::handle::ResourceHandle;
 use crate::config::PoolConfig;
 use crate::utils::{base58, base64};
 
 use super::types::{Message, Verifiers};
 use super::{Networker, NetworkerEvent, NetworkerFactory, RequestExtEvent, RequestHandle};
 
-new_handle_type!(ZMQSocketHandle, ZSC_COUNTER);
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[repr(transparent)]
+pub struct ZMQSocketHandle(pub i64);
 
-new_handle_type!(ZMQConnectionHandle, ZCH_COUNTER);
+impl_sequence_handle!(ZMQSocketHandle, ZSC_COUNTER);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[repr(transparent)]
+pub struct ZMQConnectionHandle(pub i64);
+
+impl_sequence_handle!(ZMQConnectionHandle, ZCH_COUNTER);
 
 /// ZeroMQ `NetworkerFactory` implementation
 #[derive(Default)]

--- a/libindy_vdr/src/pool/types.rs
+++ b/libindy_vdr/src/pool/types.rs
@@ -654,7 +654,11 @@ impl PoolSetup {
     }
 }
 
-new_handle_type!(RequestHandle, RQ_COUNTER);
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[repr(transparent)]
+pub struct RequestHandle(pub i64);
+
+impl_sequence_handle!(RequestHandle, RQ_COUNTER);
 
 /// Common result type returned by request handlers
 #[derive(Debug)]

--- a/libindy_vdr/src/resolver/did_document.rs
+++ b/libindy_vdr/src/resolver/did_document.rs
@@ -1,6 +1,6 @@
 use crate::common::error::prelude::*;
 use crate::ledger::responses::Endpoint;
-use indy_utils::base58;
+use crate::utils::base58;
 use serde::{Deserialize, Serialize};
 use serde_json::{self, Value as SJsonValue};
 

--- a/libindy_vdr/src/utils/mod.rs
+++ b/libindy_vdr/src/utils/mod.rs
@@ -6,6 +6,8 @@ pub mod base64;
 pub mod txn_signature;
 
 // re-exports
-pub use indy_utils::did;
-pub use indy_utils::keys;
-pub use indy_utils::{qualifiable, ConversionError, Qualifiable, Validatable, ValidationError};
+pub use indy_data_types::did;
+pub use indy_data_types::keys;
+pub use indy_data_types::{
+    qualifiable, ConversionError, Qualifiable, Validatable, ValidationError,
+};

--- a/libindy_vdr/tests/utils/fixtures.rs
+++ b/libindy_vdr/tests/utils/fixtures.rs
@@ -1,4 +1,4 @@
-use indy_utils::base58;
+use bs58;
 use rand::{thread_rng, Rng};
 
 use crate::utils::constants::*;
@@ -62,7 +62,7 @@ pub fn non_self_cert_identity() -> Identity {
     let mut id = Identity::new(None, None);
     let mut rng = thread_rng();
     let rand_arr: [u8; 16] = rng.gen();
-    let did = base58::encode(rand_arr);
+    let did = bs58::encode(rand_arr).into_string();
     id.did = DidValue(did);
     id
 }


### PR DESCRIPTION
The functionality of indy-utils has been merged into indy-data-types in 0.7. This update includes the new versions of the ed25519/curve25519-dalek dependencies.