### PR TITLE
Update zmq and time dependencies

### DIFF
--- a/libindy_vdr/Cargo.toml
+++ b/libindy_vdr/Cargo.toml
@@ -21,15 +21,12 @@ crate-type = ["staticlib", "rlib", "cdylib"]
 [features]
 ffi = ["ffi-support", "logger"]
 logger = ["env_logger", "log"]
-zmq_vendored = ["zmq/vendored"]
+zmq_vendored = []                             # now automatic
 local_nodes_pool = []
 rich_schema = ["indy-data-types/rich_schema"]
-default = ["ffi", "log", "zmq_vendored"]
+default = ["ffi", "log"]
 
 [dependencies]
-# This is added so we can lock the version that zmq uses
-# 0.1.49 is broken for ios targets
-cmake = { version = "=0.1.48", optional = true }
 base64 = "0.21"
 bs58 = "0.5"
 etcommon-rlp = "0.2.4"
@@ -57,9 +54,9 @@ serde_json = "1.0"
 sha2 = "0.10"
 sha3 = "0.10"
 thiserror = "1.0"
-time = { version = "=0.3.20", features = ["parsing"] }
+time = { version = "0.3", features = ["parsing"] }
 url = "2.2.2"
-zmq = "0.9"
+zmq = "0.10"
 
 [dev-dependencies]
 rstest = "0.18"


### PR DESCRIPTION
I believe `time` was only locked in the past to maintain a lower minimum Rust version.

`cmake` is no longer used to build the zmq source and there doesn't appear to be a need for the `vendored` flag.

Fixes #225 