### PR TITLE
Faster pool refresh

### DIFF
--- a/indy-vdr-proxy/src/handlers.rs
+++ b/indy-vdr-proxy/src/handlers.rs
@@ -13,7 +13,9 @@ use super::AppState;
 use indy_vdr::common::error::prelude::*;
 use indy_vdr::ledger::identifiers::{CredentialDefinitionId, RevocationRegistryId, SchemaId};
 use indy_vdr::pool::helpers::{perform_get_txn, perform_ledger_request};
-use indy_vdr::pool::{LedgerType, Pool, PreparedRequest, RequestResult, TimingResult};
+use indy_vdr::pool::{
+    LedgerType, Pool, PreparedRequest, RequestResult, RequestResultMeta, TimingResult,
+};
 use indy_vdr::resolver::did::DidUrl;
 use indy_vdr::resolver::PoolResolver as Resolver;
 use indy_vdr::utils::did::DidValue;
@@ -34,16 +36,16 @@ enum ResponseType {
     Resolver(String),
 }
 
-impl<T> From<(RequestResult<T>, Option<TimingResult>)> for ResponseType
+impl<T> From<(RequestResult<T>, RequestResultMeta)> for ResponseType
 where
     T: std::fmt::Display,
 {
-    fn from(result: (RequestResult<T>, Option<TimingResult>)) -> ResponseType {
+    fn from(result: (RequestResult<T>, RequestResultMeta)) -> ResponseType {
         match result {
-            (RequestResult::Reply(message), timing) => {
-                ResponseType::RequestReply(message.to_string(), timing)
+            (RequestResult::Reply(message), meta) => {
+                ResponseType::RequestReply(message.to_string(), meta.timing)
             }
-            (RequestResult::Failed(err), timing) => ResponseType::RequestFailed(err, timing),
+            (RequestResult::Failed(err), meta) => ResponseType::RequestFailed(err, meta.timing),
         }
     }
 }

--- a/indy-vdr-proxy/src/main.rs
+++ b/indy-vdr-proxy/src/main.rs
@@ -313,7 +313,7 @@ async fn refresh_pool(
         tokio::time::sleep(Duration::from_secs((delay_mins * 60 / n_pools) as u64)).await
     }
 
-    let (txns, _timing) = perform_refresh(pool).await?;
+    let (txns, _meta) = perform_refresh(pool).await?;
 
     let cloned_state = state.clone();
     let pool_states = &cloned_state.borrow().pool_states;

--- a/libindy_vdr/Cargo.toml
+++ b/libindy_vdr/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "indy-vdr"
-version = "0.4.0"
+version = "0.4.1"
 authors = [
     "Hyperledger Indy Contributors <hyperledger-indy@lists.hyperledger.org>",
 ]

--- a/libindy_vdr/src/config/constants.rs
+++ b/libindy_vdr/src/config/constants.rs
@@ -3,10 +3,10 @@ use once_cell::sync::Lazy;
 
 use crate::pool::ProtocolVersion;
 
-pub const DEFAULT_ACK_TIMEOUT: i64 = 20;
-pub const DEFAULT_REPLY_TIMEOUT: i64 = 60;
+pub const DEFAULT_ACK_TIMEOUT: i64 = 5;
+pub const DEFAULT_REPLY_TIMEOUT: i64 = 30;
 pub const DEFAULT_CONN_ACTIVE_TIMEOUT: i64 = 5;
-pub const DEFAULT_CONN_REQUEST_LIMIT: usize = 5;
+pub const DEFAULT_CONN_REQUEST_LIMIT: usize = 10;
 pub const DEFAULT_REQUEST_READ_NODES: usize = 2;
 pub const DEFAULT_FRESHNESS_TIMEOUT: u64 = 300;
 pub const DEFAULT_PROTOCOL_VERSION: ProtocolVersion = ProtocolVersion::Node1_4;

--- a/libindy_vdr/src/ffi/pool.rs
+++ b/libindy_vdr/src/ffi/pool.rs
@@ -1,7 +1,7 @@
 use crate::common::error::prelude::*;
 use crate::common::handle::ResourceHandle;
 use crate::pool::{
-    PoolBuilder, PoolRunner, PoolTransactions, RequestMethod, RequestResult, TimingResult,
+    PoolBuilder, PoolRunner, PoolTransactions, RequestMethod, RequestResult, RequestResultMeta,
 };
 
 use std::collections::{btree_map::Entry, BTreeMap, HashMap};
@@ -227,7 +227,7 @@ pub extern "C" fn indy_vdr_pool_get_verifiers(
 }
 
 fn handle_request_result(
-    result: VdrResult<(RequestResult<String>, Option<TimingResult>)>,
+    result: VdrResult<(RequestResult<String>, RequestResultMeta)>,
 ) -> (ErrorCode, String) {
     match result {
         Ok((reply, _timing)) => match reply {

--- a/libindy_vdr/src/ffi/pool.rs
+++ b/libindy_vdr/src/ffi/pool.rs
@@ -107,7 +107,7 @@ pub extern "C" fn indy_vdr_pool_refresh(
         pool.refresh(Box::new(
             move |result| {
                 let errcode = match result {
-                    Ok((old_txns, new_txns, _timing)) => {
+                    Ok((old_txns, new_txns, _meta)) => {
                         if let Some(new_txns) = new_txns {
                             // We must spawn a new thread here because this callback
                             // is being run in the PoolRunner's thread, and if we drop
@@ -230,7 +230,7 @@ fn handle_request_result(
     result: VdrResult<(RequestResult<String>, RequestResultMeta)>,
 ) -> (ErrorCode, String) {
     match result {
-        Ok((reply, _timing)) => match reply {
+        Ok((reply, _meta)) => match reply {
             RequestResult::Reply(body) => (ErrorCode::Success, body),
             RequestResult::Failed(err) => {
                 let code = ErrorCode::from(err.kind());

--- a/libindy_vdr/src/lib.rs
+++ b/libindy_vdr/src/lib.rs
@@ -32,7 +32,7 @@
 //! // Create a new GET_TXN request and dispatch it
 //! let ledger_type = 1;  // 1 identifies the Domain ledger, see pool::LedgerType
 //! let seq_no = 1;       // Transaction sequence number
-//! let (result, _timing) = block_on(perform_get_txn(&pool, ledger_type, seq_no)).unwrap();
+//! let (result, _meta) = block_on(perform_get_txn(&pool, ledger_type, seq_no)).unwrap();
 
 #![cfg_attr(feature = "fatal_warnings", deny(warnings))]
 #![recursion_limit = "1024"] // for select! macro usage

--- a/libindy_vdr/src/pool/genesis.rs
+++ b/libindy_vdr/src/pool/genesis.rs
@@ -155,7 +155,9 @@ impl std::fmt::Debug for PoolTransactions {
 
 impl std::fmt::Display for PoolTransactions {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let vec_json = unwrap_or_return!(self.encode_json(), Err(std::fmt::Error {}));
+        let Ok(vec_json) = self.encode_json() else {
+            return Err(std::fmt::Error {});
+        };
         let txns = SJsonValue::from(vec_json);
         write!(f, "{}", txns)
     }

--- a/libindy_vdr/src/pool/handlers/mod.rs
+++ b/libindy_vdr/src/pool/handlers/mod.rs
@@ -119,16 +119,13 @@ impl<K: Eq + Hash, T: Eq + Hash> ConsensusState<K, T> {
         }
     }
 
-    fn max_entry(&self) -> Option<(&K, usize)> {
-        self.inner
-            .iter()
-            .map(|(key, set)| (key, set.len()))
-            .max_by_key(|entry| entry.1)
+    fn max_entry(&self) -> Option<(&K, &HashSet<T>)> {
+        self.inner.iter().max_by_key(|entry| entry.1.len())
     }
 
     #[allow(dead_code)]
     fn max_len(&self) -> usize {
-        self.max_entry().map(|entry| entry.1).unwrap_or(0)
+        self.max_entry().map(|entry| entry.1.len()).unwrap_or(0)
     }
 
     pub fn insert(&mut self, key: K, reply: T) -> &mut HashSet<T> {

--- a/libindy_vdr/src/pool/handlers/mod.rs
+++ b/libindy_vdr/src/pool/handlers/mod.rs
@@ -10,7 +10,7 @@ use crate::utils::{base58, ValidationError};
 use super::requests::{PoolRequest, RequestEvent};
 use super::types::{
     self, CatchupReq, LedgerStatus, LedgerType, Message, NodeReplies, ProtocolVersion,
-    RequestResult, SingleReply, TimingResult,
+    RequestResult, RequestResultMeta, SingleReply,
 };
 
 mod catchup;

--- a/libindy_vdr/src/pool/handlers/status.rs
+++ b/libindy_vdr/src/pool/handlers/status.rs
@@ -1,5 +1,7 @@
-use futures_util::stream::StreamExt;
 use std::cmp::Ordering;
+use std::collections::HashSet;
+
+use futures_util::stream::StreamExt;
 
 use crate::common::error::prelude::*;
 use crate::common::merkle_tree::MerkleTree;
@@ -11,7 +13,7 @@ use super::{
     RequestResult, RequestResultMeta,
 };
 
-pub type CatchupTarget = (Vec<u8>, usize);
+pub type CatchupTarget = (Vec<u8>, usize, Vec<String>);
 
 pub async fn handle_status_request<R: PoolRequest>(
     request: &mut R,
@@ -82,11 +84,8 @@ pub async fn handle_status_request<R: PoolRequest>(
                     request.get_meta(),
                 ));
             }
-            Ok(CatchupProgress::ShouldBeStarted(target_mt_root, target_mt_size)) => {
-                return Ok((
-                    RequestResult::Reply(Some((target_mt_root, target_mt_size))),
-                    request.get_meta(),
-                ));
+            Ok(CatchupProgress::ShouldBeStarted(target)) => {
+                return Ok((RequestResult::Reply(Some(target)), request.get_meta()));
             }
             Err(err) => return Ok((RequestResult::Failed(err), request.get_meta())),
         };
@@ -94,10 +93,7 @@ pub async fn handle_status_request<R: PoolRequest>(
 }
 
 enum CatchupProgress {
-    ShouldBeStarted(
-        Vec<u8>, //target_mt_root
-        usize,   //target_mt_size
-    ),
+    ShouldBeStarted(CatchupTarget),
     NoConsensus,
     NotNeeded,
     InProgress,
@@ -110,9 +106,10 @@ fn check_nodes_responses_on_status<R>(
     total_nodes_count: usize,
     f: usize,
 ) -> VdrResult<CatchupProgress> {
-    let max_consensus = if let Some((most_popular_vote, votes_count)) = consensus.max_entry() {
+    let max_consensus = if let Some((most_popular_vote, votes)) = consensus.max_entry() {
+        let votes_count = votes.len();
         if votes_count > f {
-            return try_to_catch_up(most_popular_vote, merkle_tree);
+            return try_to_catch_up(most_popular_vote, merkle_tree, votes);
         }
         votes_count
     } else {
@@ -127,6 +124,7 @@ fn check_nodes_responses_on_status<R>(
 fn try_to_catch_up(
     ledger_status: &(String, usize, Option<Vec<String>>),
     merkle_tree: &MerkleTree,
+    nodes: &HashSet<String>,
 ) -> VdrResult<CatchupProgress> {
     let &(ref target_mt_root, target_mt_size, ref hashes) = ledger_status;
     let cur_mt_size = merkle_tree.count();
@@ -153,10 +151,11 @@ fn try_to_catch_up(
                 }
             };
 
-            Ok(CatchupProgress::ShouldBeStarted(
+            Ok(CatchupProgress::ShouldBeStarted((
                 target_mt_root,
                 target_mt_size,
-            ))
+                nodes.iter().cloned().collect(),
+            )))
         }
         _ => Err(input_err("Local merkle tree greater than mt from ledger")),
     }

--- a/libindy_vdr/src/pool/helpers.rs
+++ b/libindy_vdr/src/pool/helpers.rs
@@ -156,9 +156,9 @@ pub async fn perform_ledger_request<T: Pool>(
             node_aliases,
             timeout,
         } => {
-            let (result, timing) =
+            let (result, meta) =
                 handle_full_request(&mut request, node_aliases.clone(), *timeout).await?;
-            return Ok((result.map_result(format_full_reply)?, timing));
+            return Ok((result.map_result(format_full_reply)?, meta));
         }
         RequestMethod::BuiltinStateProof {
             sp_key,

--- a/libindy_vdr/src/pool/mod.rs
+++ b/libindy_vdr/src/pool/mod.rs
@@ -22,6 +22,7 @@ pub use self::requests::{
 };
 pub use self::runner::{PoolRunner, PoolRunnerStatus};
 pub use self::types::{
-    LedgerType, NodeReplies, PoolSetup, ProtocolVersion, RequestHandle, RequestResult, SingleReply,
-    TimingResult, VerifierInfo, VerifierKey, VerifierKeys, Verifiers,
+    LedgerType, NodeReplies, PoolSetup, ProtocolVersion, RequestHandle, RequestResult,
+    RequestResultMeta, SingleReply, StateProofAssertions, StateProofResult, TimingResult,
+    VerifierInfo, VerifierKey, VerifierKeys, Verifiers,
 };

--- a/libindy_vdr/src/pool/requests/base.rs
+++ b/libindy_vdr/src/pool/requests/base.rs
@@ -10,9 +10,10 @@ use pin_utils::unsafe_pinned;
 
 use crate::common::error::prelude::*;
 use crate::config::PoolConfig;
+use crate::pool::types::StateProofResult;
 
 use super::networker::{Networker, NetworkerEvent};
-use super::types::{RequestHandle, TimingResult, VerifierKeys};
+use super::types::{RequestHandle, RequestResultMeta, TimingResult, VerifierKeys};
 use super::PoolSetup;
 use super::{RequestEvent, RequestExtEvent, RequestState, RequestTiming};
 
@@ -21,6 +22,7 @@ use super::{RequestEvent, RequestExtEvent, RequestState, RequestTiming};
 pub trait PoolRequest: std::fmt::Debug + Stream<Item = RequestEvent> + FusedStream + Unpin {
     fn clean_timeout(&self, node_alias: String) -> VdrResult<()>;
     fn extend_timeout(&self, node_alias: String, timeout: i64) -> VdrResult<()>;
+    fn get_meta(&self) -> RequestResultMeta;
     fn get_timing(&self) -> Option<TimingResult>;
     fn is_active(&self) -> bool;
     fn node_count(&self) -> usize;
@@ -30,6 +32,7 @@ pub trait PoolRequest: std::fmt::Debug + Stream<Item = RequestEvent> + FusedStre
     fn send_to_all(&mut self, timeout: i64) -> VdrResult<()>;
     fn send_to_any(&mut self, count: usize, timeout: i64) -> VdrResult<Vec<String>>;
     fn send_to(&mut self, node_aliases: Vec<String>, timeout: i64) -> VdrResult<Vec<String>>;
+    fn set_state_proof_result(&mut self, node_alias: String, res: StateProofResult);
 }
 
 /// Default `PoolRequestImpl` used by `PoolImpl`
@@ -41,6 +44,7 @@ pub struct PoolRequestImpl<S: AsRef<PoolSetup>, T: Networker> {
     networker: T,
     send_count: usize,
     state: RequestState,
+    state_proof: HashMap<String, StateProofResult>,
     timing: RequestTiming,
 }
 
@@ -65,6 +69,7 @@ where
             networker,
             node_order,
             send_count: 0,
+            state_proof: HashMap::new(),
             state: RequestState::NotStarted,
             timing: RequestTiming::new(),
         }
@@ -97,6 +102,13 @@ where
             node_alias,
             timeout,
         ))
+    }
+
+    fn get_meta(&self) -> RequestResultMeta {
+        RequestResultMeta {
+            state_proof: self.state_proof.clone(),
+            timing: self.timing.result(),
+        }
     }
 
     fn get_timing(&self) -> Option<TimingResult> {
@@ -181,6 +193,10 @@ where
             self.send_count += aliases.len();
         }
         Ok(aliases)
+    }
+
+    fn set_state_proof_result(&mut self, node_alias: String, res: StateProofResult) {
+        self.state_proof.insert(node_alias, res);
     }
 }
 

--- a/libindy_vdr/src/pool/requests/mod.rs
+++ b/libindy_vdr/src/pool/requests/mod.rs
@@ -99,8 +99,12 @@ impl RequestTiming {
     }
 
     pub fn result(&self) -> Option<TimingResult> {
-        Some(HashMap::from_iter(
-            self.replies.iter().map(|(k, (_, v))| (k.clone(), *v)),
-        ))
+        if self.replies.is_empty() {
+            None
+        } else {
+            Some(HashMap::from_iter(
+                self.replies.iter().map(|(k, (_, v))| (k.clone(), *v)),
+            ))
+        }
     }
 }

--- a/libindy_vdr/src/pool/runner.rs
+++ b/libindy_vdr/src/pool/runner.rs
@@ -10,7 +10,7 @@ use futures_util::{select, FutureExt};
 use super::helpers::{perform_ledger_request, perform_refresh};
 use super::networker::{Networker, NetworkerFactory};
 use super::requests::PreparedRequest;
-use super::types::{RequestResult, TimingResult, Verifiers};
+use super::types::{RequestResult, RequestResultMeta, Verifiers};
 use super::{LocalPool, Pool};
 use crate::common::error::prelude::*;
 use crate::common::merkle_tree::MerkleTree;
@@ -118,9 +118,9 @@ type GetTxnsResponse = VdrResult<Vec<String>>;
 
 type GetVerifiersResponse = VdrResult<Verifiers>;
 
-type RefreshResponse = VdrResult<(Vec<String>, Option<Vec<String>>, Option<TimingResult>)>;
+type RefreshResponse = VdrResult<(Vec<String>, Option<Vec<String>>, RequestResultMeta)>;
 
-type SendReqResponse = VdrResult<(RequestResult<String>, Option<TimingResult>)>;
+type SendReqResponse = VdrResult<(RequestResult<String>, RequestResultMeta)>;
 
 enum PoolEvent {
     GetStatus(Callback<GetStatusResponse>),

--- a/libindy_vdr/src/pool/runner.rs
+++ b/libindy_vdr/src/pool/runner.rs
@@ -213,8 +213,8 @@ impl PoolThread {
 async fn _perform_refresh(pool: &LocalPool, callback: Callback<RefreshResponse>) {
     let result = {
         match perform_refresh(pool).await {
-            Ok((new_txns, timing)) => match pool.get_json_transactions() {
-                Ok(old_txns) => Ok((old_txns, new_txns, timing)),
+            Ok((new_txns, meta)) => match pool.get_json_transactions() {
+                Ok(old_txns) => Ok((old_txns, new_txns, meta)),
                 Err(err) => Err(err),
             },
             Err(err) => Err(err),

--- a/libindy_vdr/src/pool/types.rs
+++ b/libindy_vdr/src/pool/types.rs
@@ -679,8 +679,48 @@ impl<T> RequestResult<T> {
     }
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct StateProofAssertions {
+    pub ledger_id: i32,
+    pub pool_state_root_hash: String,
+    pub state_root_hash: String,
+    pub timestamp: u64,
+    pub txn_root_hash: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum StateProofResult {
+    Missing,
+    Invalid(String),
+    Expired(StateProofAssertions),
+    Verified(StateProofAssertions),
+}
+
+impl StateProofResult {
+    pub fn is_verified(&self) -> bool {
+        matches!(self, Self::Verified(_))
+    }
+}
+
+impl std::fmt::Display for StateProofResult {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            Self::Missing => f.write_str("Missing state proof"),
+            Self::Invalid(msg) => f.write_fmt(format_args!("Invalid state proof: {msg}")),
+            Self::Expired(_) => f.write_str("Expired state proof"),
+            Self::Verified(_) => f.write_str("Verified state proof"),
+        }
+    }
+}
+
 /// Type representing timing information collected for ledger transaction request
 pub type TimingResult = HashMap<String, f32>;
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct RequestResultMeta {
+    pub state_proof: HashMap<String, StateProofResult>,
+    pub timing: Option<TimingResult>,
+}
 
 /// The result of a request to a single validator node
 #[derive(Debug)]

--- a/libindy_vdr/src/pool/types.rs
+++ b/libindy_vdr/src/pool/types.rs
@@ -691,7 +691,7 @@ pub struct StateProofAssertions {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum StateProofResult {
     Missing,
-    Invalid(String),
+    Invalid(String, Option<StateProofAssertions>),
     Expired(StateProofAssertions),
     Verified(StateProofAssertions),
 }
@@ -706,7 +706,7 @@ impl std::fmt::Display for StateProofResult {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         match self {
             Self::Missing => f.write_str("Missing state proof"),
-            Self::Invalid(msg) => f.write_fmt(format_args!("Invalid state proof: {msg}")),
+            Self::Invalid(msg, _asserts) => f.write_fmt(format_args!("Invalid state proof: {msg}")),
             Self::Expired(_) => f.write_str("Expired state proof"),
             Self::Verified(_) => f.write_str("Verified state proof"),
         }

--- a/libindy_vdr/src/resolver/pool.rs
+++ b/libindy_vdr/src/resolver/pool.rs
@@ -2,7 +2,7 @@ use super::did::DidUrl;
 use crate::common::error::prelude::*;
 
 use crate::ledger::RequestBuilder;
-use crate::pool::{Pool, PoolRunner, RequestResult, TimingResult};
+use crate::pool::{Pool, PoolRunner, RequestResult, RequestResultMeta};
 
 use super::types::*;
 use super::utils::*;
@@ -158,7 +158,7 @@ impl<'a> PoolRunnerResolver<'a> {
     }
 }
 
-type SendReqResponse = VdrResult<(RequestResult<String>, Option<TimingResult>)>;
+type SendReqResponse = VdrResult<(RequestResult<String>, RequestResultMeta)>;
 
 pub fn handle_resolution_result(result: SendReqResponse, did_url: String) -> VdrResult<String> {
     let did = DidUrl::parse(did_url.as_str())?;

--- a/libindy_vdr/src/resolver/pool.rs
+++ b/libindy_vdr/src/resolver/pool.rs
@@ -162,7 +162,7 @@ type SendReqResponse = VdrResult<(RequestResult<String>, RequestResultMeta)>;
 
 pub fn handle_resolution_result(result: SendReqResponse, did_url: String) -> VdrResult<String> {
     let did = DidUrl::parse(did_url.as_str())?;
-    let (req_result, _timing_result) = result?;
+    let (req_result, _meta) = result?;
 
     let ledger_data = match req_result {
         RequestResult::Reply(reply_data) => Ok(reply_data),

--- a/libindy_vdr/src/resolver/utils.rs
+++ b/libindy_vdr/src/resolver/utils.rs
@@ -12,7 +12,7 @@ use crate::ledger::identifiers::{CredentialDefinitionId, RevocationRegistryId, S
 use crate::ledger::responses::{Endpoint, GetNymResultV1};
 use crate::ledger::RequestBuilder;
 use crate::pool::helpers::perform_ledger_request;
-use crate::pool::{Pool, PreparedRequest, RequestResult, TimingResult};
+use crate::pool::{Pool, PreparedRequest, RequestResult, RequestResultMeta};
 use crate::utils::did::DidValue;
 use crate::utils::Qualifiable;
 
@@ -262,7 +262,7 @@ pub async fn handle_request<T: Pool>(pool: &T, request: &PreparedRequest) -> Vdr
 pub async fn request_transaction<T: Pool>(
     pool: &T,
     request: &PreparedRequest,
-) -> VdrResult<(RequestResult<String>, Option<TimingResult>)> {
+) -> VdrResult<(RequestResult<String>, RequestResultMeta)> {
     perform_ledger_request(pool, request).await
 }
 

--- a/libindy_vdr/src/resolver/utils.rs
+++ b/libindy_vdr/src/resolver/utils.rs
@@ -252,7 +252,7 @@ pub fn parse_or_now(datetime: Option<&String>) -> VdrResult<i64> {
 }
 
 pub async fn handle_request<T: Pool>(pool: &T, request: &PreparedRequest) -> VdrResult<String> {
-    let (result, _timing) = request_transaction(pool, request).await?;
+    let (result, _meta) = request_transaction(pool, request).await?;
     match result {
         RequestResult::Reply(data) => Ok(data),
         RequestResult::Failed(error) => Err(error),

--- a/libindy_vdr/src/state_proof/mod.rs
+++ b/libindy_vdr/src/state_proof/mod.rs
@@ -14,7 +14,7 @@ use serde_json::Value as SJsonValue;
 use sha2::{Digest, Sha256};
 
 use crate::common::error::prelude::*;
-use crate::pool::{ProtocolVersion, VerifierKeys};
+use crate::pool::{ProtocolVersion, StateProofAssertions, StateProofResult, VerifierKeys};
 use crate::utils::base58;
 use crate::utils::base64;
 
@@ -91,7 +91,7 @@ pub(crate) fn check_state_proof(
     last_write_time: u64,
     threshold: u64,
     custom_state_proof_parser: Option<&BoxedSPParser>,
-) -> bool {
+) -> StateProofResult {
     trace!("process_reply: Try to verify proof and signature >>");
 
     let res = match parse_generic_reply_for_proof_checking(
@@ -102,26 +102,23 @@ pub(crate) fn check_state_proof(
     ) {
         Some(parsed_sps) => {
             trace!("process_reply: Proof and signature are present");
-            if verify_parsed_sp(parsed_sps, bls_keys, f, gen) {
-                if check_freshness(msg_result, requested_timestamps, last_write_time, threshold) {
-                    true
-                } else {
-                    debug!("Freshness check failed");
-                    false
+            match verify_parsed_sp(parsed_sps, bls_keys, f, gen) {
+                Ok(asserts) => {
+                    if check_freshness(msg_result, requested_timestamps, last_write_time, threshold)
+                    {
+                        StateProofResult::Verified(asserts)
+                    } else {
+                        StateProofResult::Expired(asserts)
+                    }
                 }
-            } else {
-                debug!("Verification of parsed state proof failed");
-                false
+                Err(err) => StateProofResult::Invalid(err),
             }
         }
-        None => {
-            debug!("No state proof found");
-            false
-        }
+        None => StateProofResult::Missing,
     };
 
     trace!(
-        "process_reply: Try to verify proof and signature << {}",
+        "process_reply: Try to verify proof and signature << {:?}",
         res
     );
     res
@@ -282,7 +279,9 @@ pub(crate) fn verify_parsed_sp(
     nodes: &VerifierKeys,
     f: usize,
     gen: &Generator,
-) -> bool {
+) -> Result<StateProofAssertions, String> {
+    let mut multi_sig: Option<SJsonValue> = None;
+
     for parsed_sp in parsed_sps {
         if parsed_sp.multi_signature["value"]["state_root_hash"]
             .as_str()
@@ -291,48 +290,40 @@ pub(crate) fn verify_parsed_sp(
                 .as_str()
                 .ne(&Some(&parsed_sp.root_hash))
         {
-            debug!("Given signature is not for current root hash, aborting");
-            return false;
+            return Err("Given signature does not match state proof, aborting verification".into());
         }
 
-        let (signature, participants, value) = unwrap_opt_or_return!(
-            _parse_reply_for_proof_signature_checking(&parsed_sp.multi_signature),
-            {
-                debug!("Reply parsing failed");
-                false
+        match multi_sig.as_ref() {
+            Some(sig) => {
+                if sig != &parsed_sp.multi_signature {
+                    return Err("No consistency between proof multi signatures".into());
+                }
             }
-        );
-        if !_verify_proof_signature(signature, participants.as_slice(), &value, nodes, f, gen)
-            .map_err(|err| debug!("Proof signature verification failed: {}", err))
-            .unwrap_or(false)
-        {
-            return false;
+            None => {
+                multi_sig.replace(parsed_sp.multi_signature);
+            }
         }
 
-        let proof_nodes = unwrap_or_return!(base64::decode(&parsed_sp.proof_nodes), {
-            debug!("Error decoding proof nodes from state proof");
-            false
-        });
-        let root_hash = unwrap_or_return!(base58::decode(parsed_sp.root_hash), {
-            debug!("Error decoding root hash from state proof");
-            false
-        });
+        let Ok(proof_nodes) = base64::decode(&parsed_sp.proof_nodes) else {
+            return Err("Error decoding proof nodes from state proof".into());
+        };
+        let Ok(root_hash) = base58::decode(parsed_sp.root_hash) else {
+            return Err("Error decoding root hash from state proof".into());
+        };
         match parsed_sp.kvs_to_verify {
             KeyValuesInSP::Simple(kvs) => match kvs.verification_type {
                 KeyValueSimpleDataVerificationType::Simple => {
                     for (k, v) in kvs.kvs {
-                        let key = unwrap_or_return!(base64::decode(&k), {
-                            debug!("Error decoding proof key");
-                            false
-                        });
+                        let Ok(key) = base64::decode(&k) else {
+                            return Err("Error decoding proof key".into());
+                        };
                         if !_verify_proof(
                             proof_nodes.as_slice(),
                             root_hash.as_slice(),
                             &key,
                             v.as_deref(),
                         ) {
-                            debug!("Simple verification failed");
-                            return false;
+                            return Err("Simple verification failed".into());
                         }
                     }
                 }
@@ -345,8 +336,7 @@ pub(crate) fn verify_parsed_sp(
                         data.next,
                         &kvs.kvs,
                     ) {
-                        debug!("Range verification failed");
-                        return false;
+                        return Err("Range verification failed".into());
                     }
                 }
                 KeyValueSimpleDataVerificationType::MerkleTree(length) => {
@@ -356,22 +346,32 @@ pub(crate) fn verify_parsed_sp(
                         &kvs.kvs,
                         length,
                     ) {
-                        return false;
+                        return Err("Merkle tree verification failed".into());
                     }
                 }
             },
             //TODO IS-713 support KeyValuesInSP::SubTrie
             kvs => {
-                debug!(
-                    "Unsupported parsed state proof format for key-values {:?} ",
-                    kvs
-                );
-                return false;
+                return Err(format!(
+                    "Unsupported parsed state proof format for key-values: {kvs:?}"
+                ));
             }
         }
     }
 
-    true
+    if let Some(multi_sig) = multi_sig.as_ref() {
+        let Some((signature, participants, value)) = _parse_reply_for_proof_signature_checking(multi_sig) else {
+            return Err("State proof parsing of reply failed".into());
+        };
+        _verify_proof_signature(signature, participants.as_slice(), &value, nodes, f, gen)
+            .map_err(|err| format!("Proof signature verification failed: {}", err))?;
+        let Ok(asserts) = serde_json::from_value(multi_sig["value"].clone()) else {
+            return Err("Error parsing state proof assertions".into());
+        };
+        Ok(asserts)
+    } else {
+        Err("Proof signature verification failed: no parsed state proofs".into())
+    }
 }
 
 pub(crate) fn parse_key_from_request_for_builtin_sp(
@@ -905,19 +905,21 @@ fn _verify_merkle_tree(
     length: u64,
 ) -> bool {
     let (key, value) = &kvs[0];
-    if value.is_none() {
+    let Some(value) = value.as_ref() else {
         debug!("No value for merkle tree hash");
         return false;
-    }
-    let seq_no = in_closure! {
-        let key = base64::decode(key).map_err_string()?;
-        let key = std::str::from_utf8(&key).map_err_string()?;
-        key.parse::<u64>().map_err_string()
     };
-    let seq_no = unwrap_or_map_return!(seq_no, |err| {
-        debug!("Error while parsing merkle tree seq_no: {}", err);
-        false
-    });
+    let seq_no = match base64::decode(key)
+        .map_err_string()
+        .and_then(|key| String::from_utf8(key).map_err_string())
+        .and_then(|key| key.parse::<u64>().map_err_string())
+    {
+        Ok(seq_no) => seq_no,
+        Err(err) => {
+            debug!("Error while parsing merkle tree seq_no: {}", err);
+            return false;
+        }
+    };
 
     let turns = _calculate_turns(length, seq_no - 1);
 
@@ -951,10 +953,10 @@ fn _verify_merkle_tree(
 
     let mut path = Vec::with_capacity(hashes.len());
     for (hash, t_right) in hashes.into_iter().zip(turns) {
-        let hash = unwrap_or_return!(base58::decode(hash), {
+        let Ok(hash) = base58::decode(hash) else {
             debug!("Error decoding hash as base58");
-            false
-        });
+            return false;
+        };
         path.push(if t_right {
             Positioned::Right(hash)
         } else {
@@ -962,15 +964,16 @@ fn _verify_merkle_tree(
         });
     }
 
-    let leaf_value = in_closure! {
-        let val = value.as_ref().unwrap();
-        let val = serde_json::from_str::<serde_json::Value>(val).map_err_string()?;
-        rmp_serde::to_vec(&val).map_err_string()
+    let leaf_value = match serde_json::from_str::<serde_json::Value>(value)
+        .map_err_string()
+        .and_then(|val| rmp_serde::to_vec(&val).map_err_string())
+    {
+        Ok(val) => val,
+        Err(err) => {
+            debug!("Error while decoding merkle tree leaf: {:?}", err);
+            return false;
+        }
     };
-    let leaf_value = unwrap_or_map_return!(leaf_value, |err| {
-        debug!("Error while decoding merkle tree leaf: {:?}", err);
-        false
-    });
 
     trace!("Leaf value: {}", base58::encode(&leaf_value));
 
@@ -1112,14 +1115,14 @@ fn _verify_proof_signature(
     nodes: &VerifierKeys,
     f: usize,
     gen: &Generator,
-) -> VdrResult<bool> {
+) -> Result<(), String> {
     let mut ver_keys: Vec<&VerKey> = Vec::with_capacity(nodes.len());
 
     for name in participants {
         if let Some(blskey) = nodes.get(name) {
             ver_keys.push(&blskey.inner)
         } else {
-            return Err(input_err(format!("BLS key not found for node: {:?}", name)));
+            return Err(format!("BLS key not found for node: {:?}", name));
         }
     }
 
@@ -1129,25 +1132,23 @@ fn _verify_proof_signature(
     );
 
     if ver_keys.len() < (nodes.len() - f) {
-        return Ok(false);
+        return Err("Insufficient participants in multi signature".into());
     }
 
-    let signature = if let Ok(signature) = base58::decode(signature) {
+    let signature = if let Some(signature) = base58::decode(signature)
+        .ok()
+        .and_then(|sig| MultiSignature::from_bytes(sig.as_slice()).ok())
+    {
         signature
     } else {
-        return Ok(false);
+        return Err("Error decoding multi signature".into());
     };
 
-    let signature = if let Ok(signature) = MultiSignature::from_bytes(signature.as_slice()) {
-        signature
-    } else {
-        return Ok(false);
-    };
+    if !Bls::verify_multi_sig(&signature, value, ver_keys.as_slice(), gen).unwrap_or(false) {
+        return Err("Multi signature failed verification".into());
+    }
 
-    let res = Bls::verify_multi_sig(&signature, value, ver_keys.as_slice(), gen).unwrap_or(false);
-
-    trace!("verify_proof_signature: <<< res: {:?}", res);
-    Ok(res)
+    Ok(())
 }
 
 fn _parse_reply_for_proof_value(
@@ -2283,17 +2284,43 @@ mod tests {
         bls_keys.insert("Node4".to_owned(), VerifierKey::from_bytes(&hex::decode("136feaf1ad5b81d70de5c5287b0ef24746b8db60dba8ec502aeb213ae5c9f1900b59ff8e6f38e00e5d4cf2a45fb3317a0ccfc710806d368acb2267e097ed696611cc9295d2bbca32d1e176f026a66f02f70a8851ec71f2f4321dc62f00b5cf071f32e6fc3a1f63278360c7dd8285224ed482ff59ab5063aee3117a111fc9ffd2").unwrap()).unwrap());
         let reply: serde_json::Value = serde_json::from_str(raw_msg).unwrap();
         let msg_result = &reply["result"];
-        assert!(check_state_proof(
-            msg_result,
-            f,
-            &DEFAULT_GENERATOR,
-            &bls_keys,
-            raw_msg,
-            Some(&[49]),
-            (None, Some(0)),
-            1691520806,
-            300,
-            None,
-        ));
+        let asserts = StateProofAssertions {
+            ledger_id: 1,
+            pool_state_root_hash: "7siDH8Qanh82UviK4zjBSfLXcoCvLaeGkrByi1ow9Tsm".into(),
+            state_root_hash: "8AasPY2KBtPLiVnvePAZhPZKAfRozAR9CBUYAXFBhdXo".into(),
+            timestamp: 1691520806,
+            txn_root_hash: "DxX9E3XxEPHbb3JjakcmSduPc2bBcWsFhZZGp5aa842q".into(),
+        };
+        assert_eq!(
+            check_state_proof(
+                msg_result,
+                f,
+                &DEFAULT_GENERATOR,
+                &bls_keys,
+                raw_msg,
+                Some(&[49]),
+                (None, Some(0)),
+                1691520806,
+                300,
+                None,
+            ),
+            StateProofResult::Verified(asserts.clone())
+        );
+
+        assert_eq!(
+            check_state_proof(
+                msg_result,
+                f,
+                &DEFAULT_GENERATOR,
+                &bls_keys,
+                raw_msg,
+                Some(&[49]),
+                (None, Some(1691521806)),
+                1691520806,
+                300,
+                None,
+            ),
+            StateProofResult::Expired(asserts)
+        );
     }
 }

--- a/libindy_vdr/src/utils/macros.rs
+++ b/libindy_vdr/src/utils/macros.rs
@@ -60,38 +60,3 @@ macro_rules! map_err_log {
         }
     };
 }
-
-macro_rules! unwrap_opt_or_return {
-    ($opt:expr, $err:expr) => {
-        match $opt {
-            Some(val) => val,
-            None => return $err,
-        }
-    };
-}
-
-macro_rules! unwrap_or_return {
-    ($result:expr, $err:expr) => {
-        match $result {
-            Ok(res) => res,
-            Err(_) => return $err,
-        }
-    };
-}
-
-macro_rules! unwrap_or_map_return {
-    ($result:expr, $on_err:expr) => {
-        match $result {
-            Ok(res) => res,
-            Err(err) =>
-            {
-                #[allow(clippy::redundant_closure_call)]
-                return ($on_err)(err)
-            }
-        }
-    };
-}
-
-macro_rules! in_closure {
-    ($($e:tt)*) => {(|| -> Result<_, _> {$($e)*})()}
-}

--- a/libindy_vdr/tests/utils/pool.rs
+++ b/libindy_vdr/tests/utils/pool.rs
@@ -60,7 +60,7 @@ impl TestPool {
 
     pub fn send_request(&self, prepared_request: &PreparedRequest) -> Result<String, String> {
         block_on(async {
-            let (request_result, _timing) = perform_ledger_request(&self.pool, prepared_request)
+            let (request_result, _meta) = perform_ledger_request(&self.pool, prepared_request)
                 .await
                 .unwrap();
 
@@ -78,7 +78,7 @@ impl TestPool {
         timeout: Option<i64>,
     ) -> VdrResult<NodeReplies<String>> {
         block_on(async {
-            let (request_result, _timing) = perform_ledger_action(
+            let (request_result, _meta) = perform_ledger_action(
                 &self.pool,
                 prepared_request.req_id.clone(),
                 prepared_request.req_json.to_string(),


### PR DESCRIPTION
- Capture additional information about the state proof multi-signature verification.
- After performing a successful status request, prioritize the responding nodes when performing a subsequent catchup request. This helps to avoid delays waiting for nodes that are no longer active.
- Adjust default configuration parameters: ack_timeout -> 5 seconds, read timeout -> 30 seconds, connection request limit -> 10 requests.