### PR TITLE
Add genesis transactions caching

### DIFF
--- a/indy-vdr-proxy/src/handlers.rs
+++ b/indy-vdr-proxy/src/handlers.rs
@@ -246,7 +246,7 @@ fn http_status_msg<T: std::fmt::Display>(code: StatusCode, msg: T) -> VdrResult<
 }
 
 async fn get_pool_genesis<T: Pool>(pool: &T) -> VdrResult<ResponseType> {
-    let txns = pool.get_json_transactions()?;
+    let txns = pool.get_transactions().encode_json()?;
     Ok(ResponseType::Genesis(txns.join("\n")))
 }
 

--- a/indy-vdr-proxy/src/main.rs
+++ b/indy-vdr-proxy/src/main.rs
@@ -315,7 +315,9 @@ async fn refresh_pool(
 
     let (txns, _meta) = perform_refresh(pool).await?;
     if let Some(txns) = txns {
-        let pool = PoolBuilder::new(PoolConfig::default(), txns).into_local()?;
+        let pool = PoolBuilder::new(PoolConfig::default(), txns)
+            .refreshed(true)
+            .into_local()?;
         Ok(Some(pool))
     } else {
         Ok(None)

--- a/indy-vdr-proxy/src/main.rs
+++ b/indy-vdr-proxy/src/main.rs
@@ -36,7 +36,6 @@ use hyper_tls::HttpsConnector;
 #[cfg(unix)]
 use hyper_unix_connector::UnixConnector;
 
-use indy_vdr::config::PoolConfig;
 #[cfg(feature = "tls")]
 use rustls_pemfile::{certs, pkcs8_private_keys};
 #[cfg(feature = "tls")]
@@ -51,6 +50,7 @@ use tokio_rustls::{
 };
 
 use indy_vdr::common::error::prelude::*;
+use indy_vdr::config::PoolConfig;
 use indy_vdr::pool::{helpers::perform_refresh, LocalPool, PoolBuilder, PoolTransactions};
 
 use crate::utils::{

--- a/indy-vdr-proxy/src/utils.rs
+++ b/indy-vdr-proxy/src/utils.rs
@@ -27,9 +27,10 @@ pub fn init_pool_state_from_folder_structure(
 
     let entries = fs::read_dir(path).map_err(|err| {
         err_msg(
-            VdrErrorKind::FileSystem(err),
+            VdrErrorKind::FileSystem,
             "Could not read local networks folder",
         )
+        .with_source(err)
     })?;
 
     for entry in entries {

--- a/libindy_vdr/src/common/error.rs
+++ b/libindy_vdr/src/common/error.rs
@@ -27,8 +27,8 @@ pub enum VdrErrorKind {
     Config,
     #[error("Connection error")]
     Connection,
-    #[error("File system error: {0}")]
-    FileSystem(std::io::Error),
+    #[error("File system error")]
+    FileSystem,
     #[error("Input error")]
     Input,
     #[error("Resource error")]
@@ -69,6 +69,14 @@ impl VdrError {
             _ => None,
         }
     }
+
+    pub fn with_source<E>(mut self, source: E) -> Self
+    where
+        E: Into<Box<dyn std::error::Error + Send + Sync>>,
+    {
+        self.source.replace(source.into());
+        self
+    }
 }
 
 impl fmt::Display for VdrError {
@@ -107,6 +115,12 @@ impl From<crate::utils::ConversionError> for VdrError {
 impl From<crate::utils::ValidationError> for VdrError {
     fn from(err: crate::utils::ValidationError) -> Self {
         VdrError::new(VdrErrorKind::Input, Some(err.to_string()), None)
+    }
+}
+
+impl From<std::io::Error> for VdrError {
+    fn from(err: std::io::Error) -> VdrError {
+        VdrError::new(VdrErrorKind::FileSystem, None, Some(Box::new(err)))
     }
 }
 

--- a/libindy_vdr/src/ffi/error.rs
+++ b/libindy_vdr/src/ffi/error.rs
@@ -31,7 +31,7 @@ impl From<&VdrErrorKind> for ErrorCode {
         match kind {
             VdrErrorKind::Config => ErrorCode::Config,
             VdrErrorKind::Connection => ErrorCode::Connection,
-            VdrErrorKind::FileSystem(_) => ErrorCode::FileSystem,
+            VdrErrorKind::FileSystem => ErrorCode::FileSystem,
             VdrErrorKind::Input => ErrorCode::Input,
             VdrErrorKind::Resource => ErrorCode::Resource,
             VdrErrorKind::Unavailable => ErrorCode::Unavailable,

--- a/libindy_vdr/src/ffi/mod.rs
+++ b/libindy_vdr/src/ffi/mod.rs
@@ -15,8 +15,7 @@ mod resolver;
 
 use crate::common::error::prelude::*;
 use crate::config::{PoolConfig, LIB_VERSION};
-use crate::pool::ProtocolVersion;
-use crate::pool::{FilesystemCache, PoolTransactionsCache};
+use crate::pool::{FilesystemCache, PoolTransactionsCache, ProtocolVersion};
 use crate::utils::Validatable;
 
 use self::error::{set_last_error, ErrorCode};
@@ -62,10 +61,10 @@ pub extern "C" fn indy_vdr_set_protocol_version(version: i64) -> ErrorCode {
 pub extern "C" fn indy_vdr_set_cache_directory(path: FfiStr) -> ErrorCode {
     catch_err! {
         let cache = if let Some(path) = path.as_opt_str() {
-            trace!("Initializing filesystem pool transactions cache");
+            debug!("Initializing filesystem pool transactions cache");
             Some(Arc::new(FilesystemCache::new(path)) as Arc<dyn PoolTransactionsCache>)
         } else {
-            trace!("Clearing filesystem pool transactions cache");
+            debug!("Clearing filesystem pool transactions cache");
             None
         };
         *write_lock!(POOL_CACHE)? = cache;

--- a/libindy_vdr/src/ffi/resolver.rs
+++ b/libindy_vdr/src/ffi/resolver.rs
@@ -19,7 +19,7 @@ pub extern "C" fn indy_vdr_resolve(
         let pools = read_lock!(POOLS)?;
         let pool = pools.get(&pool_handle).ok_or_else(|| input_err("Unknown pool handle"))?;
         let did = did.as_str().to_owned();
-        let resolver = Resolver::new(pool);
+        let resolver = Resolver::new(&pool.runner);
         resolver
         .dereference(
             did.clone(),
@@ -52,7 +52,7 @@ pub extern "C" fn indy_vdr_dereference(
         let pools = read_lock!(POOLS)?;
         let pool = pools.get(&pool_handle).ok_or_else(|| input_err("Unknown pool handle"))?;
         let did_url = did_url.as_str().to_owned();
-        let resolver = Resolver::new(pool);
+        let resolver = Resolver::new(&pool.runner);
         resolver.dereference(
             did_url.clone(),
             Box::new(move |ledger_reply| {

--- a/libindy_vdr/src/lib.rs
+++ b/libindy_vdr/src/lib.rs
@@ -14,6 +14,7 @@
 //!
 //! ```no_run
 //! use futures_executor::block_on;
+//! use indy_vdr::config::PoolConfig;
 //! use indy_vdr::pool::{
 //!     helpers::perform_get_txn,
 //!     PoolBuilder,
@@ -25,7 +26,7 @@
 //! let txns = PoolTransactions::from_json_file("./genesis.txn").unwrap();
 //!
 //! // Create a PoolBuilder instance
-//! let pool_builder = PoolBuilder::default().transactions(txns).unwrap();
+//! let pool_builder = PoolBuilder::new(PoolConfig::default(), txns);
 //! // Convert into a thread-local Pool instance
 //! let pool = pool_builder.into_local().unwrap();
 //!

--- a/libindy_vdr/src/pool/builder.rs
+++ b/libindy_vdr/src/pool/builder.rs
@@ -1,40 +1,29 @@
+use std::collections::HashMap;
+
+use crate::common::error::prelude::*;
+use crate::config::PoolConfig;
+
 use super::genesis::PoolTransactions;
 use super::manager::{LocalPool, SharedPool};
 use super::networker::{MakeLocal, MakeShared, ZMQNetworkerFactory};
 use super::runner::PoolRunner;
 
-use crate::common::error::prelude::*;
-use crate::common::merkle_tree::MerkleTree;
-use crate::config::PoolConfig;
-
-use std::collections::HashMap;
-
 /// A utility class for building a new pool instance or runner.
 #[derive(Clone)]
 pub struct PoolBuilder {
     pub config: PoolConfig,
-    merkle_tree: Option<MerkleTree>,
+    transactions: PoolTransactions,
     node_weights: Option<HashMap<String, f32>>,
 }
 
 impl PoolBuilder {
     /// Create a new `PoolBuilder` instance.
-    pub fn new(
-        config: PoolConfig,
-        merkle_tree: Option<MerkleTree>,
-        node_weights: Option<HashMap<String, f32>>,
-    ) -> Self {
+    pub fn new(config: PoolConfig, transactions: PoolTransactions) -> Self {
         Self {
             config,
-            merkle_tree,
-            node_weights,
+            transactions,
+            node_weights: None,
         }
-    }
-
-    /// Replace the builder's pool transactions from a `MerkleTree` instance.
-    pub fn merkle_tree(mut self, merkle_tree: MerkleTree) -> Self {
-        self.merkle_tree.replace(merkle_tree);
-        self
     }
 
     /// Set the node weights associated with the builder.
@@ -43,24 +32,12 @@ impl PoolBuilder {
         self
     }
 
-    /// Replace the builder's pool transactions.
-    pub fn transactions(mut self, transactions: PoolTransactions) -> VdrResult<Self> {
-        let merkle_tree = transactions.into_merkle_tree()?;
-        self.merkle_tree.replace(merkle_tree);
-        Ok(self)
-    }
-
     /// Create a `LocalPool` instance from the builder, for use in a single thread.
     pub fn into_local(self) -> VdrResult<LocalPool> {
-        if self.merkle_tree.is_none() {
-            return Err(err_msg(
-                VdrErrorKind::Config,
-                "No pool transactions provided",
-            ));
-        }
+        let merkle_tree = self.transactions.merkle_tree()?;
         LocalPool::build(
             self.config,
-            self.merkle_tree.unwrap(),
+            merkle_tree,
             MakeLocal(ZMQNetworkerFactory {}),
             self.node_weights,
         )
@@ -68,15 +45,11 @@ impl PoolBuilder {
 
     /// Create a `SharedPool` instance from the builder, for use across multiple threads.
     pub fn into_shared(self) -> VdrResult<SharedPool> {
-        if self.merkle_tree.is_none() {
-            return Err(err_msg(
-                VdrErrorKind::Config,
-                "No pool transactions provided",
-            ));
-        }
+        let merkle_tree = self.transactions.merkle_tree()?;
+
         SharedPool::build(
             self.config,
-            self.merkle_tree.unwrap(),
+            merkle_tree,
             MakeShared(ZMQNetworkerFactory {}),
             self.node_weights,
         )
@@ -85,29 +58,12 @@ impl PoolBuilder {
     /// Create a `PoolRunner` instance from the builder, to handle pool interaction
     /// in a dedicated thread.
     pub fn into_runner(self) -> VdrResult<PoolRunner> {
-        if self.merkle_tree.is_none() {
-            return Err(err_msg(
-                VdrErrorKind::Config,
-                "No pool transactions provided",
-            ));
-        }
+        let merkle_tree = self.transactions.merkle_tree()?;
         Ok(PoolRunner::new(
             self.config,
-            self.merkle_tree.unwrap(),
+            merkle_tree,
             MakeLocal(ZMQNetworkerFactory {}),
             self.node_weights,
         ))
-    }
-}
-
-impl Default for PoolBuilder {
-    fn default() -> Self {
-        PoolBuilder::new(PoolConfig::default(), None, None)
-    }
-}
-
-impl From<PoolConfig> for PoolBuilder {
-    fn from(config: PoolConfig) -> Self {
-        PoolBuilder::new(config, None, None)
     }
 }

--- a/libindy_vdr/src/pool/builder.rs
+++ b/libindy_vdr/src/pool/builder.rs
@@ -14,6 +14,7 @@ pub struct PoolBuilder {
     pub config: PoolConfig,
     transactions: PoolTransactions,
     node_weights: Option<HashMap<String, f32>>,
+    refreshed: bool,
 }
 
 impl PoolBuilder {
@@ -23,7 +24,14 @@ impl PoolBuilder {
             config,
             transactions,
             node_weights: None,
+            refreshed: false,
         }
+    }
+
+    /// Enable or disable the fast refresh option.
+    pub fn refreshed(mut self, flag: bool) -> Self {
+        self.refreshed = flag;
+        self
     }
 
     /// Set the node weights associated with the builder.
@@ -40,6 +48,7 @@ impl PoolBuilder {
             merkle_tree,
             MakeLocal(ZMQNetworkerFactory {}),
             self.node_weights,
+            self.refreshed,
         )
     }
 
@@ -52,6 +61,7 @@ impl PoolBuilder {
             merkle_tree,
             MakeShared(ZMQNetworkerFactory {}),
             self.node_weights,
+            self.refreshed,
         )
     }
 
@@ -64,6 +74,7 @@ impl PoolBuilder {
             merkle_tree,
             MakeLocal(ZMQNetworkerFactory {}),
             self.node_weights,
+            self.refreshed,
         ))
     }
 }

--- a/libindy_vdr/src/pool/genesis.rs
+++ b/libindy_vdr/src/pool/genesis.rs
@@ -1,10 +1,12 @@
 use std::collections::HashMap;
 use std::convert::TryFrom;
-use std::fs::File;
-use std::io::BufReader;
+use std::fs::{self, File};
+use std::io::{self, BufReader};
 use std::iter::IntoIterator;
-use std::path::Path;
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, Mutex};
 
+use rand::random;
 use serde_json::{self, Deserializer, Value as SJsonValue};
 
 use super::types::{
@@ -19,6 +21,11 @@ use crate::utils::{
 };
 
 pub type NodeTransactionMap = HashMap<String, NodeTransactionV1>;
+
+#[cfg(windows)]
+const LINE_ENDING: &str = "\r\n";
+#[cfg(not(windows))]
+const LINE_ENDING: &str = "\n";
 
 /// A collection of pool genesis transactions.
 #[derive(Clone, PartialEq, Eq)]
@@ -50,9 +57,10 @@ impl PoolTransactions {
     {
         let f = File::open(&file_name).map_err(|err| {
             err_msg(
-                VdrErrorKind::FileSystem(err),
+                VdrErrorKind::FileSystem,
                 format!("Can't open genesis transactions file: {:?}", file_name),
             )
+            .with_source(err)
         })?;
         let reader = BufReader::new(&f);
         let stream = Deserializer::from_reader(reader).into_iter::<SJsonValue>();
@@ -116,6 +124,11 @@ impl PoolTransactions {
         Ok(MerkleTree::from_vec(self.inner)?)
     }
 
+    /// Get the root hash corresponding to the transactions
+    pub fn root_hash_base58(&self) -> VdrResult<String> {
+        Ok(base58::encode(self.merkle_tree()?.root_hash()))
+    }
+
     /// Iterate the set of transactions as a sequence of msgpack-encoded byte strings.
     pub fn iter(&self) -> impl Iterator<Item = &Vec<u8>> {
         self.inner.iter()
@@ -128,6 +141,16 @@ impl PoolTransactions {
             .into_iter()
             .map(|v| v.to_string())
             .collect())
+    }
+
+    /// Get a sequence of JSON strings representing the pool transactions.
+    pub fn encode_json_string(&self) -> VdrResult<String> {
+        let mut buf = String::new();
+        for line in self.json_values()? {
+            buf.push_str(&line.to_string());
+            buf.push_str(LINE_ENDING);
+        }
+        Ok(buf)
     }
 
     /// Get a sequence of `serde_json::Value` instances representing the pool transactions.
@@ -208,6 +231,114 @@ where
             err
         ))),
     })
+}
+
+pub trait PoolTransactionsCache: Clone {
+    fn resolve_latest(&self, txns: &PoolTransactions) -> VdrResult<Option<PoolTransactions>>;
+
+    fn update(&self, base: &PoolTransactions, latest: &PoolTransactions) -> VdrResult<()>;
+}
+
+#[derive(Debug, Clone)]
+struct _MemoryCacheEntry {
+    txns: PoolTransactions,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct InMemoryCache {
+    cache: Arc<Mutex<HashMap<String, _MemoryCacheEntry>>>,
+}
+
+impl InMemoryCache {
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+impl PoolTransactionsCache for InMemoryCache {
+    fn resolve_latest(&self, txns: &PoolTransactions) -> VdrResult<Option<PoolTransactions>> {
+        let hash = txns.root_hash_base58()?;
+        let cache = self.cache.lock().unwrap();
+        if let Some(entry) = cache.get(&hash) {
+            Ok(Some(entry.txns.clone()))
+        } else {
+            Ok(None)
+        }
+    }
+
+    fn update(&self, base: &PoolTransactions, latest: &PoolTransactions) -> VdrResult<()> {
+        let from_hash = base.root_hash_base58()?;
+        let mut cache = self.cache.lock().unwrap();
+        cache
+            .entry(from_hash)
+            .and_modify(|e| e.txns = latest.clone())
+            .or_insert_with(|| _MemoryCacheEntry {
+                txns: latest.clone(),
+            });
+        Ok(())
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct FilesystemCache {
+    cache_dir: PathBuf,
+}
+
+impl FilesystemCache {
+    pub fn new<P: Into<PathBuf>>(path: P) -> Self {
+        Self {
+            cache_dir: path.into(),
+        }
+    }
+
+    fn establish(&self, ident: &str) -> VdrResult<()> {
+        Ok(fs::create_dir_all(self.cache_dir.join(ident))?)
+    }
+
+    fn read_cache_file(&self, ident: &str, name: &str) -> Option<String> {
+        let mut path = self.cache_dir.clone();
+        path.extend(&[ident, name]);
+        fs::read_to_string(path)
+            .map_err(|e| {
+                if e.kind() != io::ErrorKind::NotFound {
+                    warn!("Error reading from pool genesis cache: {e}")
+                }
+            })
+            .ok()
+    }
+
+    fn write_cache_file(&self, ident: &str, name: &str, contents: &str) -> VdrResult<()> {
+        self.establish(ident)?;
+        let mut target_path = self.cache_dir.clone();
+        target_path.push(ident);
+        let temp_name = format!("{:020}.tmp", random::<u64>());
+        let temp_path = target_path.join(temp_name);
+        target_path.push(name);
+        fs::write(&temp_path, contents.as_bytes())
+            .and_then(|_| fs::rename(&temp_path, &target_path))
+            .map_err(|e| warn!("Error writing from pool genesis cache: {e}"))
+            .ok();
+        Ok(())
+    }
+}
+
+impl PoolTransactionsCache for FilesystemCache {
+    fn resolve_latest(&self, txns: &PoolTransactions) -> VdrResult<Option<PoolTransactions>> {
+        let ident = txns.root_hash_base58()?;
+        if let Some(txns) = self.read_cache_file(&ident, "txns") {
+            Ok(PoolTransactions::from_json(&txns)
+                .map_err(|e| warn!("Error reading from pool genesis cache: {e}"))
+                .ok())
+        } else {
+            Ok(None)
+        }
+    }
+
+    fn update(&self, base: &PoolTransactions, latest: &PoolTransactions) -> VdrResult<()> {
+        let ident = base.root_hash_base58()?;
+        self.write_cache_file(&ident, "txns", &latest.encode_json_string()?)?;
+        Ok(())
+    }
 }
 
 pub fn build_node_transaction_map<T>(
@@ -370,6 +501,8 @@ fn _decode_transaction(
 
 #[cfg(test)]
 mod tests {
+    use std::env::temp_dir;
+
     use super::*;
 
     const NODE1: &str = r#"{"reqSignature":{},"txn":{"data":{"data":{"alias":"Node1","blskey":"4N8aUNHSgjQVgkpm8nhNEfDf6txHznoYREg9kirmJrkivgL4oSEimFF6nsQ6M41QvhM2Z33nves5vfSn9n1UwNFJBYtWVnHYMATn76vLuL3zU88KyeAYcHfsih3He6UHcXDxcaecHVz6jhCYz1P2UZn2bDVruL5wXpehgBfBaLKm3Ba","blskey_pop":"RahHYiCvoNCtPTrVtP7nMC5eTYrsUA8WjXbdhNc8debh1agE9bGiJxWBXYNFbnJXoXhWFMvyqhqhRoq737YQemH5ik9oL7R4NTTCz2LEZhkgLJzB3QRQqJyBNyv7acbdHrAT8nQ9UkLbaVL9NBpnWXBTw4LEMePaSHEw66RzPNdAX1","client_ip":"127.0.0.1","client_port":9702,"node_ip":"127.0.0.1","node_port":9701,"services":["VALIDATOR"]},"dest":"Gw6pDLhcBcoQesN72qfotTgFa7cbuqZpkX3Xo6pLhPhv"},"metadata":{"from":"Th7MpTaRZVRYnPiabds81Y"},"type":"0"},"txnMetadata":{"seqNo":1,"txnId":"fea82e10e894419fe2bea7d96296a6d46f50f93f9eeda954ec461b2ed2950b62"},"ver":"1"}"#;
@@ -378,11 +511,12 @@ mod tests {
     const NODE1_OLD: &str = r#"{"data":{"alias":"Node1","client_ip":"192.168.1.35","client_port":9702,"node_ip":"192.168.1.35","node_port":9701,"services":["VALIDATOR"]},"dest":"Gw6pDLhcBcoQesN72qfotTgFa7cbuqZpkX3Xo6pLhPhv","identifier":"FYmoFw55GeQH7SRFa37dkx1d2dZ3zUF8ckg7wmL7ofN4","txnId":"fea82e10e894419fe2bea7d96296a6d46f50f93f9eeda954ec461b2ed2950b62","type":"0"}"#;
     const NODE2_OLD: &str = r#"{"data":{"alias":"Node2","client_ip":"192.168.1.35","client_port":9704,"node_ip":"192.168.1.35","node_port":9703,"services":["VALIDATOR"]},"dest":"8ECVSk179mjsjKRLWiQtssMLgp6EPhWXtaYyStWPSGAb","identifier":"8QhFxKxyaFsJy4CyxeYX34dFH8oWqyBv1P4HLQCsoeLy","txnId":"1ac8aece2a18ced660fef8694b61aac3af08ba875ce3026a160acbc3a3af35fc","type":"0"}"#;
 
-    pub fn _merkle_tree() -> MerkleTree {
-        PoolTransactions::from_json_transactions(&[NODE1, NODE2, NODE3])
-            .unwrap()
-            .merkle_tree()
-            .unwrap()
+    fn _merkle_tree() -> MerkleTree {
+        _transactions().merkle_tree().unwrap()
+    }
+
+    fn _transactions() -> PoolTransactions {
+        PoolTransactions::from_json_transactions(&[NODE1, NODE2, NODE3]).unwrap()
     }
 
     #[test]
@@ -448,5 +582,48 @@ mod tests {
             .unwrap();
 
         let _err = build_node_transaction_map(merkle_tree, ProtocolVersion::Node1_4).unwrap_err();
+    }
+
+    #[test]
+    fn test_in_memory_cache() {
+        let txns = _transactions();
+        let cache = InMemoryCache::new();
+        assert_eq!(cache.resolve_latest(&txns).unwrap(), None);
+        let mut txns_long = txns.clone();
+        txns_long.extend_from_json(&[NODE1_OLD]).unwrap();
+        cache.update(&txns, &txns_long).unwrap();
+        assert_eq!(
+            cache.resolve_latest(&txns).unwrap().as_ref(),
+            Some(&txns_long)
+        );
+        txns_long.extend_from_json(&[NODE2_OLD]).unwrap();
+        cache.update(&txns, &txns_long).unwrap();
+        assert_eq!(
+            cache.resolve_latest(&txns).unwrap().as_ref(),
+            Some(&txns_long)
+        );
+    }
+
+    #[test]
+    fn test_fs_cache() {
+        let temp_name = format!("vdr-test-{:020}", random::<u64>());
+        let temp_dir = temp_dir().join(temp_name);
+        let txns = _transactions();
+        let cache = FilesystemCache::new(&temp_dir);
+        assert_eq!(cache.resolve_latest(&txns).unwrap(), None);
+        let mut txns_long = txns.clone();
+        txns_long.extend_from_json(&[NODE1_OLD]).unwrap();
+        cache.update(&txns, &txns_long).unwrap();
+        assert_eq!(
+            cache.resolve_latest(&txns).unwrap().as_ref(),
+            Some(&txns_long)
+        );
+        txns_long.extend_from_json(&[NODE2_OLD]).unwrap();
+        cache.update(&txns, &txns_long).unwrap();
+        assert_eq!(
+            cache.resolve_latest(&txns).unwrap().as_ref(),
+            Some(&txns_long)
+        );
+        fs::remove_dir_all(&temp_dir).unwrap();
     }
 }

--- a/libindy_vdr/src/pool/handlers/catchup.rs
+++ b/libindy_vdr/src/pool/handlers/catchup.rs
@@ -8,7 +8,7 @@ use super::{check_cons_proofs, PoolRequest, RequestEvent, RequestResult, Request
 
 pub async fn handle_catchup_request<R: PoolRequest>(
     request: &mut R,
-    merkle_tree: MerkleTree,
+    merkle_tree: &MerkleTree,
     target_mt_root: Vec<u8>,
     target_mt_size: usize,
 ) -> VdrResult<(RequestResult<Vec<Vec<u8>>>, RequestResultMeta)> {
@@ -21,7 +21,7 @@ pub async fn handle_catchup_request<R: PoolRequest>(
             Some(RequestEvent::Received(node_alias, _message, parsed)) => match parsed {
                 Message::CatchupRep(cr) => {
                     match process_catchup_reply(
-                        &merkle_tree,
+                        merkle_tree,
                         &target_mt_root,
                         target_mt_size,
                         cr.load_txns()?,

--- a/libindy_vdr/src/pool/handlers/mod.rs
+++ b/libindy_vdr/src/pool/handlers/mod.rs
@@ -187,13 +187,13 @@ fn check_cons_proofs(
 }
 
 pub(crate) fn build_pool_status_request(
-    merkle_root: &[u8],
+    merkle_root: String,
     merkle_tree_size: usize,
     protocol_version: ProtocolVersion,
 ) -> VdrResult<Message> {
     let lr = LedgerStatus {
         txnSeqNo: merkle_tree_size,
-        merkleRoot: base58::encode(merkle_root),
+        merkleRoot: merkle_root,
         ledgerId: LedgerType::POOL as u8,
         ppSeqNo: None,
         viewNo: None,

--- a/libindy_vdr/src/pool/helpers.rs
+++ b/libindy_vdr/src/pool/helpers.rs
@@ -13,62 +13,86 @@ use super::requests::{PoolRequest, PreparedRequest, RequestMethod};
 use super::types::{NodeReplies, RequestResult, RequestResultMeta};
 
 use crate::common::error::prelude::*;
-use crate::common::merkle_tree::MerkleTree;
-use crate::pool::{LedgerType, StateProofResult};
+use crate::pool::LedgerType;
 use crate::utils::base58;
 
 /// Perform a pool ledger status request to see if catchup is required
 pub async fn perform_pool_status_request<T: Pool>(
     pool: &T,
-    merkle_tree: MerkleTree,
 ) -> VdrResult<(RequestResult<Option<CatchupTarget>>, RequestResultMeta)> {
-    let (mt_root, mt_size) = (merkle_tree.root_hash(), merkle_tree.count());
+    let (mt_root, mt_size) = pool.get_merkle_tree_info();
+
+    if pool.get_refreshed() {
+        trace!("Performing fast status check");
+        match perform_get_txn(pool, LedgerType::POOL.to_id(), 1).await {
+            Ok((RequestResult::Reply(reply), res_meta)) => {
+                if let Ok(body) = serde_json::from_str::<serde_json::Value>(&reply) {
+                    if let (Some(status_root_hash), Some(status_txn_count)) = (
+                        body["result"]["data"]["rootHash"].as_str(),
+                        body["result"]["data"]["ledgerSize"].as_u64(),
+                    ) {
+                        let target = if status_root_hash == mt_root
+                            && status_txn_count == mt_size as u64
+                        {
+                            debug!("Fast status check succeeded, pool state is up to date");
+                            None
+                        } else {
+                            debug!("Fast status check got catchup target: {}", status_root_hash);
+                            let target_mt_hash = base58::decode(status_root_hash)
+                                .map_err(|_| invalid!("Can't decode status target root hash"))?;
+                            Some((
+                                target_mt_hash,
+                                status_txn_count as usize,
+                                res_meta.state_proof.keys().cloned().collect(),
+                            ))
+                        };
+                        return Ok((RequestResult::Reply(target), res_meta));
+                    } else {
+                        warn!("Error retrieving transaction count from fast status request");
+                    }
+                } else {
+                    warn!("Error parsing response from fast status request");
+                }
+            }
+            Ok((RequestResult::Failed(err), _)) | Err(err) => {
+                warn!("Failed fast status request: {err}")
+            }
+        }
+    }
+
     let message = build_pool_status_request(mt_root, mt_size, pool.get_config().protocol_version)?;
     let req_json = message.serialize()?.to_string();
     let mut request = pool.create_request("".to_string(), req_json).await?;
-    handle_status_request(&mut request, merkle_tree).await
+    handle_status_request(&mut request, pool.get_merkle_tree()).await
 }
 
 /// Perform a pool ledger catchup request to fetch the latest verifier pool transactions
 pub async fn perform_pool_catchup_request<T: Pool>(
     pool: &T,
-    merkle_tree: MerkleTree,
     target_mt_root: Vec<u8>,
     target_mt_size: usize,
     preferred_nodes: Option<Vec<String>>,
 ) -> VdrResult<(RequestResult<Vec<Vec<u8>>>, RequestResultMeta)> {
-    let message = build_pool_catchup_request(merkle_tree.count(), target_mt_size)?;
+    let message = build_pool_catchup_request(pool.get_merkle_tree().count(), target_mt_size)?;
     let req_json = message.serialize()?.to_string();
     let mut request = pool.create_request("".to_string(), req_json).await?;
     if let Some(nodes) = preferred_nodes {
         request.set_preferred_nodes(&nodes);
     }
-    handle_catchup_request(&mut request, merkle_tree, target_mt_root, target_mt_size).await
+    handle_catchup_request(
+        &mut request,
+        pool.get_merkle_tree(),
+        target_mt_root,
+        target_mt_size,
+    )
+    .await
 }
 
 /// Perform a pool ledger status request followed by a catchup request if necessary
 pub async fn perform_refresh<T: Pool>(
     pool: &T,
 ) -> VdrResult<(Option<PoolTransactions>, RequestResultMeta)> {
-    if pool.get_refreshed() {
-        trace!("Performing fast status check");
-        let mt_root = pool.get_merkle_tree_info().0;
-        match perform_get_txn(pool, LedgerType::POOL.to_id(), 1).await {
-            Ok((_result, res_meta)) => {
-                for prf in res_meta.state_proof.values() {
-                    if let StateProofResult::Verified(asserts) = prf {
-                        if asserts.txn_root_hash == mt_root {
-                            info!("Fast status check succeeded, pool state is up to date");
-                            return Ok((None, res_meta));
-                        }
-                    }
-                }
-            }
-            Err(err) => warn!("Failed fast status request: {err}"),
-        }
-    }
-    let merkle_tree = pool.get_merkle_tree().clone();
-    let (result, meta) = perform_pool_status_request(pool, merkle_tree.clone()).await?;
+    let (result, meta) = perform_pool_status_request(pool).await?;
     trace!("Got status result: {:?}", &result);
     match result {
         RequestResult::Reply(target) => match target {
@@ -79,14 +103,8 @@ pub async fn perform_refresh<T: Pool>(
                     target_mt_size,
                     meta
                 );
-                let (txns, meta) = perform_catchup(
-                    pool,
-                    merkle_tree,
-                    target_mt_root,
-                    target_mt_size,
-                    Some(nodes),
-                )
-                .await?;
+                let (txns, meta) =
+                    perform_catchup(pool, target_mt_root, target_mt_size, Some(nodes)).await?;
                 Ok((Some(txns), meta))
             }
             _ => {
@@ -103,15 +121,13 @@ pub async fn perform_refresh<T: Pool>(
 
 pub(crate) async fn perform_catchup<T: Pool>(
     pool: &T,
-    merkle_tree: MerkleTree,
     target_mt_root: Vec<u8>,
     target_mt_size: usize,
     preferred_nodes: Option<Vec<String>>,
 ) -> VdrResult<(PoolTransactions, RequestResultMeta)> {
-    let mut new_txns = PoolTransactions::from_transactions(&merkle_tree);
+    let mut new_txns = pool.get_transactions();
     let (catchup_result, meta) = perform_pool_catchup_request(
         pool,
-        merkle_tree,
         target_mt_root.clone(),
         target_mt_size,
         preferred_nodes,

--- a/libindy_vdr/src/pool/manager.rs
+++ b/libindy_vdr/src/pool/manager.rs
@@ -49,6 +49,9 @@ pub trait Pool: Clone {
         (base58::encode(tree.root_hash()), tree.count())
     }
 
+    /// Determine whether a refresh has been performed.
+    fn get_refreshed(&self) -> bool;
+
     /// Get a request builder corresponding to this verifier pool
     fn get_request_builder(&self) -> RequestBuilder {
         RequestBuilder::new(self.get_config().protocol_version)
@@ -91,6 +94,7 @@ where
         merkle_tree: MerkleTree,
         networker_factory: F,
         node_weights: Option<HashMap<String, f32>>,
+        refreshed: bool,
     ) -> VdrResult<Self>
     where
         F: NetworkerFactory<Output = T>,
@@ -98,7 +102,7 @@ where
         let txn_map = build_node_transaction_map(&merkle_tree, config.protocol_version)?;
         let verifiers = build_verifiers(txn_map)?;
         let networker = networker_factory.make_networker(config.clone(), &verifiers)?;
-        let setup = PoolSetup::new(config, merkle_tree, node_weights, verifiers);
+        let setup = PoolSetup::new(config, merkle_tree, node_weights, verifiers, refreshed);
         Ok(Self::new(S::from(Box::new(setup)), networker))
     }
 }
@@ -136,6 +140,10 @@ where
 
     fn get_config(&self) -> &PoolConfig {
         &self.setup.as_ref().config
+    }
+
+    fn get_refreshed(&self) -> bool {
+        self.setup.as_ref().refreshed
     }
 
     fn get_merkle_tree(&self) -> &MerkleTree {

--- a/libindy_vdr/src/pool/manager.rs
+++ b/libindy_vdr/src/pool/manager.rs
@@ -57,9 +57,9 @@ pub trait Pool: Clone {
         RequestBuilder::new(self.get_config().protocol_version)
     }
 
-    /// Get the set of verifier pool transactions in JSON format
-    fn get_json_transactions(&self) -> VdrResult<Vec<String>> {
-        PoolTransactions::from(self.get_merkle_tree()).encode_json()
+    /// Get the set of verifier pool transactions
+    fn get_transactions(&self) -> PoolTransactions {
+        PoolTransactions::from(self.get_merkle_tree())
     }
 
     /// Get the summarized verifier details.

--- a/libindy_vdr/src/pool/mod.rs
+++ b/libindy_vdr/src/pool/mod.rs
@@ -24,6 +24,7 @@ pub use {
     self::runner::{PoolRunner, PoolRunnerStatus},
     self::types::{
         LedgerType, NodeReplies, PoolSetup, ProtocolVersion, RequestHandle, RequestResult,
-        SingleReply, TimingResult, VerifierInfo, VerifierKey, VerifierKeys, Verifiers,
+        RequestResultMeta, SingleReply, StateProofAssertions, StateProofResult, TimingResult,
+        VerifierInfo, VerifierKey, VerifierKeys, Verifiers,
     },
 };

--- a/libindy_vdr/src/pool/mod.rs
+++ b/libindy_vdr/src/pool/mod.rs
@@ -14,15 +14,16 @@ mod requests;
 mod runner;
 mod types;
 
-pub use self::builder::PoolBuilder;
-pub use self::genesis::PoolTransactions;
-pub use self::manager::{LocalPool, Pool, PoolImpl, SharedPool};
-pub use self::requests::{
-    new_request_id, PoolRequest, PoolRequestImpl, PreparedRequest, RequestMethod,
-};
-pub use self::runner::{PoolRunner, PoolRunnerStatus};
-pub use self::types::{
-    LedgerType, NodeReplies, PoolSetup, ProtocolVersion, RequestHandle, RequestResult,
-    RequestResultMeta, SingleReply, StateProofAssertions, StateProofResult, TimingResult,
-    VerifierInfo, VerifierKey, VerifierKeys, Verifiers,
+pub use {
+    self::builder::PoolBuilder,
+    self::genesis::{FilesystemCache, InMemoryCache, PoolTransactions, PoolTransactionsCache},
+    self::manager::{LocalPool, Pool, PoolImpl, SharedPool},
+    self::requests::{
+        new_request_id, PoolRequest, PoolRequestImpl, PreparedRequest, RequestMethod,
+    },
+    self::runner::{PoolRunner, PoolRunnerStatus},
+    self::types::{
+        LedgerType, NodeReplies, PoolSetup, ProtocolVersion, RequestHandle, RequestResult,
+        SingleReply, TimingResult, VerifierInfo, VerifierKey, VerifierKeys, Verifiers,
+    },
 };

--- a/libindy_vdr/src/pool/runner.rs
+++ b/libindy_vdr/src/pool/runner.rs
@@ -187,7 +187,7 @@ impl PoolThread {
                             callback(Ok(status));
                         }
                         Some(PoolEvent::GetTransactions(callback)) => {
-                            let txns = self.pool.get_json_transactions();
+                            let txns = self.pool.get_transactions().encode_json();
                             callback(txns);
                         }
                         Some(PoolEvent::GetVerifiers(callback)) => {

--- a/libindy_vdr/src/pool/runner.rs
+++ b/libindy_vdr/src/pool/runner.rs
@@ -33,6 +33,7 @@ impl PoolRunner {
         merkle_tree: MerkleTree,
         networker_factory: F,
         node_weights: Option<HashMap<String, f32>>,
+        refreshed: bool,
     ) -> Self
     where
         F: NetworkerFactory<Output = Rc<dyn Networker>> + Send + 'static,
@@ -40,9 +41,14 @@ impl PoolRunner {
         let (sender, receiver) = unbounded();
         let worker = thread::spawn(move || {
             // FIXME handle error on build
-            let pool =
-                LocalPool::build(config.clone(), merkle_tree, networker_factory, node_weights)
-                    .unwrap();
+            let pool = LocalPool::build(
+                config.clone(),
+                merkle_tree,
+                networker_factory,
+                node_weights,
+                refreshed,
+            )
+            .unwrap();
             let mut thread = PoolThread::new(pool, receiver);
             thread.run();
             debug!("Pool thread ended")

--- a/libindy_vdr/src/pool/runner.rs
+++ b/libindy_vdr/src/pool/runner.rs
@@ -11,7 +11,8 @@ use super::helpers::{perform_ledger_request, perform_refresh};
 use super::networker::{Networker, NetworkerFactory};
 use super::requests::PreparedRequest;
 use super::types::{RequestResult, RequestResultMeta, Verifiers};
-use super::{LocalPool, Pool};
+use super::{LocalPool, Pool, PoolTransactions};
+
 use crate::common::error::prelude::*;
 use crate::common::merkle_tree::MerkleTree;
 use crate::config::PoolConfig;
@@ -118,7 +119,7 @@ type GetTxnsResponse = VdrResult<Vec<String>>;
 
 type GetVerifiersResponse = VdrResult<Verifiers>;
 
-type RefreshResponse = VdrResult<(Vec<String>, Option<Vec<String>>, RequestResultMeta)>;
+type RefreshResponse = VdrResult<(Option<PoolTransactions>, RequestResultMeta)>;
 
 type SendReqResponse = VdrResult<(RequestResult<String>, RequestResultMeta)>;
 
@@ -211,15 +212,7 @@ impl PoolThread {
 }
 
 async fn _perform_refresh(pool: &LocalPool, callback: Callback<RefreshResponse>) {
-    let result = {
-        match perform_refresh(pool).await {
-            Ok((new_txns, meta)) => match pool.get_json_transactions() {
-                Ok(old_txns) => Ok((old_txns, new_txns, meta)),
-                Err(err) => Err(err),
-            },
-            Err(err) => Err(err),
-        }
-    };
+    let result = perform_refresh(pool).await;
     callback(result);
 }
 

--- a/libindy_vdr/src/pool/types.rs
+++ b/libindy_vdr/src/pool/types.rs
@@ -636,6 +636,7 @@ pub struct PoolSetup {
     pub merkle_tree: MerkleTree,
     pub node_weights: Option<HashMap<String, f32>>,
     pub verifiers: Verifiers,
+    pub refreshed: bool,
 }
 
 impl PoolSetup {
@@ -644,12 +645,14 @@ impl PoolSetup {
         merkle_tree: MerkleTree,
         node_weights: Option<HashMap<String, f32>>,
         verifiers: Verifiers,
+        refreshed: bool,
     ) -> Self {
         Self {
             config,
             merkle_tree,
             node_weights,
             verifiers,
+            refreshed,
         }
     }
 }

--- a/libindy_vdr/tests/utils/pool.rs
+++ b/libindy_vdr/tests/utils/pool.rs
@@ -3,6 +3,7 @@ use std::env;
 use futures_executor::block_on;
 
 use indy_vdr::common::error::VdrResult;
+use indy_vdr::config::PoolConfig;
 use indy_vdr::ledger::RequestBuilder;
 use indy_vdr::pool::helpers::{perform_ledger_action, perform_ledger_request};
 use indy_vdr::pool::{
@@ -41,9 +42,7 @@ impl TestPool {
         let pool_transactions =
             PoolTransactions::from_json_transactions(default_transactions()).unwrap();
 
-        let pool = PoolBuilder::default()
-            .transactions(pool_transactions)
-            .unwrap()
+        let pool = PoolBuilder::new(PoolConfig::default(), pool_transactions)
             .into_shared()
             .unwrap();
 

--- a/libindy_vdr/tests/utils/pool.rs
+++ b/libindy_vdr/tests/utils/pool.rs
@@ -50,7 +50,7 @@ impl TestPool {
     }
 
     pub fn transactions(&self) -> Vec<String> {
-        self.pool.get_json_transactions().unwrap()
+        self.pool.get_transactions().encode_json().unwrap()
     }
 
     pub fn request_builder(&self) -> RequestBuilder {

--- a/wrappers/python/indy_vdr/__init__.py
+++ b/wrappers/python/indy_vdr/__init__.py
@@ -1,19 +1,23 @@
 """indy-vdr Python wrapper library"""
 
-from .bindings import set_config, set_protocol_version, version
+from .bindings import set_cache_directory, set_config, set_protocol_version, version
 from .error import VdrError, VdrErrorCode
 from .ledger import LedgerType
 from .pool import Pool, open_pool
 from .request import Request
+from .resolver import Resolver
 
 __all__ = [
     "open_pool",
+    "set_cache_directory",
     "set_config",
     "set_protocol_version",
+    "set_socks_proxy",
     "version",
     "LedgerType",
     "Pool",
     "Request",
+    "Resolver",
     "VdrError",
     "VdrErrorCode",
 ]

--- a/wrappers/python/indy_vdr/bindings.py
+++ b/wrappers/python/indy_vdr/bindings.py
@@ -421,6 +421,11 @@ def request_set_txn_author_agreement_acceptance(
     )
 
 
+def set_cache_directory(path: str):
+    """Set the library configuration."""
+    do_call("indy_vdr_set_cache_directory", encode_str(path))
+
+
 def set_config(config: dict):
     """Set the library configuration."""
     do_call("indy_vdr_set_config", encode_json(config))


### PR DESCRIPTION
This PR adds a new FFI method (and Python binding) to set the cache directory to use. When the cache directory is set, the library will automatically store the latest transactions for a given root hash and fetch them when creating a new pool. This means that as long as the same genesis transactions are passed in (via a string or file), it should be able to find the latest copy.

After the initial refresh of a pool, or if the transactions are cached, the library will also use a consensus `GET_TXN` request to check the latest pool state. This can be faster than the traditional status request as it will short-circuit after a single valid state proof, instead of attempting to contact all of the nodes.