### PR TITLE
Update python wrapper version to 0.4.1, proxy to 0.1.5

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -64,7 +64,7 @@ jobs:
       - if: ${{ runner.os == 'Linux' }}
         name: Pre-install cross
         run: |
-          cargo install --bins --git https://github.com/rust-embedded/cross --tag v${{ env.CROSS_VERSION }} cross
+          cargo install --bins --git https://github.com/rust-embedded/cross --locked --tag v${{ env.CROSS_VERSION }} cross
 
   test-suite:
     name: Run Test Suite
@@ -148,7 +148,7 @@ jobs:
       - if: ${{ matrix.use_cross }}
         name: Build (cross)
         run: |
-          cargo install --bins --git https://github.com/rust-embedded/cross --tag v${{ env.CROSS_VERSION }} cross
+          cargo install --bins --git https://github.com/rust-embedded/cross --locked --tag v${{ env.CROSS_VERSION }} cross
           cross build --lib --release --target ${{ matrix.target }}
 
       - if: ${{ !matrix.use_cross && matrix.architecture == 'darwin-universal' }}
@@ -379,7 +379,7 @@ jobs:
 
       - name: Build
         run: |
-          cargo install --bins --git https://github.com/rust-embedded/cross --tag v${{ env.CROSS_VERSION }} cross
+          cargo install --bins --git https://github.com/rust-embedded/cross --locked --tag v${{ env.CROSS_VERSION }} cross
           cross build --lib --release --target ${{matrix.target}} --package indy-vdr
 
       - name: Save library

--- a/indy-vdr-proxy/Cargo.toml
+++ b/indy-vdr-proxy/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "indy-vdr-proxy"
-version = "0.1.4"
+version = "0.1.5"
 authors = [
     "Hyperledger Indy Contributors <hyperledger-indy@lists.hyperledger.org>",
 ]
@@ -10,7 +10,7 @@ rust-version = "1.63"
 license = "Apache-2.0"
 
 [features]
-fetch = ["hyper-tls", "hyper/client"]
+fetch = ["hyper/client", "hyper-tls"]
 zmq_vendored = ["indy-vdr/zmq_vendored"]
 tls = ["rustls-pemfile", "tokio-rustls", "hyper/stream"]
 default = ["fetch", "zmq_vendored"]
@@ -29,11 +29,11 @@ hyper-tls = { version = "0.5", optional = true }
 log = "0.4.8"
 percent-encoding = "2"
 regex = "1.5.4"
+rustls-pemfile = { version = "1.0.3", optional = true }
 serde_json = "1.0"
 tokio = { version = "1.0", features = ["macros", "rt-multi-thread", "signal"] }
+tokio-rustls = { version = "0.24", optional = true }
 url = "2.2.2"
-rustls-pemfile = { version = "1.0.3", optional = true }
-tokio-rustls = { version = "0.24.1", optional = true }
 
 [target.'cfg(unix)'.dependencies]
 hyper-unix-connector = "0.2"

--- a/wrappers/python/indy_vdr/version.py
+++ b/wrappers/python/indy_vdr/version.py
@@ -1,3 +1,3 @@
 """indy_vdr library wrapper version."""
 
-__version__ = "0.4.0"
+__version__ = "0.4.1"


### PR DESCRIPTION
The Python package is tested against the main branch of ACA-Py.

Due to a new release of the `home` crate, the cross installation on Android was failing. The CI install command is updated to use the lockfile in the cross repository.