### PR TITLE
fix: update to indy-vdr native binary 0.4.1

### DIFF
--- a/wrappers/javascript/indy-vdr-nodejs/package.json
+++ b/wrappers/javascript/indy-vdr-nodejs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperledger/indy-vdr-nodejs",
-  "version": "0.2.0-dev.7",
+  "version": "0.2.0",
   "license": "Apache-2.0",
   "description": "Nodejs wrapper for Indy Vdr",
   "source": "src/index",
@@ -40,7 +40,7 @@
     "typescript": "~4.9.4"
   },
   "dependencies": {
-    "@hyperledger/indy-vdr-shared": "0.2.0-dev.7",
+    "@hyperledger/indy-vdr-shared": "0.2.0",
     "@mapbox/node-pre-gyp": "^1.0.10",
     "@2060.io/ffi-napi": "4.0.8",
     "@2060.io/ref-napi": "3.0.6",

--- a/wrappers/javascript/indy-vdr-react-native/package.json
+++ b/wrappers/javascript/indy-vdr-react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperledger/indy-vdr-react-native",
-  "version": "0.2.0-dev.7",
+  "version": "0.2.0",
   "license": "Apache-2.0",
   "description": "React Native wrapper for Indy Vdr",
   "source": "src/index",
@@ -40,7 +40,7 @@
     "install": "node-pre-gyp install"
   },
   "dependencies": {
-    "@hyperledger/indy-vdr-shared": "0.2.0-dev.7",
+    "@hyperledger/indy-vdr-shared": "0.2.0",
     "@mapbox/node-pre-gyp": "^1.0.10"
   },
   "devDependencies": {

--- a/wrappers/javascript/indy-vdr-shared/package.json
+++ b/wrappers/javascript/indy-vdr-shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperledger/indy-vdr-shared",
-  "version": "0.2.0-dev.7",
+  "version": "0.2.0",
   "license": "Apache-2.0",
   "description": "Shared library for using Indy VDR with NodeJS and React Native",
   "main": "build/index",

--- a/wrappers/javascript/lerna.json
+++ b/wrappers/javascript/lerna.json
@@ -1,7 +1,7 @@
 {
   "$schema": "node_modules/lerna/schemas/lerna-schema.json",
   "packages": ["indy-vdr-*"],
-  "version": "0.2.0-dev.7",
+  "version": "0.2.0",
   "npmClient": "yarn",
   "command": {
     "version": {


### PR DESCRIPTION
Signed-off-by: Timo Glastra <timo@animo.id>

NOTE: this is to the js-0.4.1 branch and the release for JS wrapper must be created from that branch

<img width="337" alt="image" src="https://github.com/hyperledger/indy-vdr/assets/23165168/01f258a4-9d96-4ca5-aa46-984b6c775f5f">
