### PR TITLE
fix(js): convert seqNo to -1 if 0

### DIFF
--- a/wrappers/javascript/indy-vdr-nodejs/package.json
+++ b/wrappers/javascript/indy-vdr-nodejs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperledger/indy-vdr-nodejs",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "license": "Apache-2.0",
   "description": "Nodejs wrapper for Indy Vdr",
   "source": "src/index",
@@ -40,10 +40,10 @@
     "typescript": "~4.9.4"
   },
   "dependencies": {
-    "@hyperledger/indy-vdr-shared": "0.2.0",
-    "@mapbox/node-pre-gyp": "^1.0.10",
     "@2060.io/ffi-napi": "4.0.8",
     "@2060.io/ref-napi": "3.0.6",
+    "@hyperledger/indy-vdr-shared": "0.2.1",
+    "@mapbox/node-pre-gyp": "^1.0.10",
     "ref-array-di": "^1.2.2",
     "ref-struct-di": "^1.1.1"
   },

--- a/wrappers/javascript/indy-vdr-react-native/cpp/indyVdr.cpp
+++ b/wrappers/javascript/indy-vdr-react-native/cpp/indyVdr.cpp
@@ -240,11 +240,13 @@ jsi::Value buildGetNymRequest(jsi::Runtime &rt, jsi::Object options) {
   auto seqNo = jsiToValue<int32_t>(rt, options, "seqNo", true);
   auto timestamp = jsiToValue<int64_t>(rt, options, "timestamp", true);
 
+  auto convertedSeqNo = seqNo == 0 ? -1 : seqNo;
+
   RequestHandle out;
 
   ErrorCode code = indy_vdr_build_get_nym_request(
       submitterDid.length() > 0 ? submitterDid.c_str() : nullptr, dest.c_str(),
-      seqNo, timestamp, &out);
+      convertedSeqNo, timestamp, &out);
 
   return createReturnValue(rt, code, &out);
 };

--- a/wrappers/javascript/indy-vdr-react-native/package.json
+++ b/wrappers/javascript/indy-vdr-react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperledger/indy-vdr-react-native",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "license": "Apache-2.0",
   "description": "React Native wrapper for Indy Vdr",
   "source": "src/index",
@@ -40,7 +40,7 @@
     "install": "node-pre-gyp install"
   },
   "dependencies": {
-    "@hyperledger/indy-vdr-shared": "0.2.0",
+    "@hyperledger/indy-vdr-shared": "0.2.1",
     "@mapbox/node-pre-gyp": "^1.0.10"
   },
   "devDependencies": {

--- a/wrappers/javascript/indy-vdr-react-native/src/NativeBindings.ts
+++ b/wrappers/javascript/indy-vdr-react-native/src/NativeBindings.ts
@@ -89,6 +89,7 @@ export interface NativeBindings {
     dest: string
     didDocContent?: string
     version?: number
+    seqNo?: number
   }): ReturnObject<RequestHandle>
 
   buildGetSchemaRequest(options: { submitterDid?: string; schemaId: string }): ReturnObject<RequestHandle>

--- a/wrappers/javascript/indy-vdr-shared/package.json
+++ b/wrappers/javascript/indy-vdr-shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperledger/indy-vdr-shared",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "license": "Apache-2.0",
   "description": "Shared library for using Indy VDR with NodeJS and React Native",
   "main": "build/index",

--- a/wrappers/javascript/lerna.json
+++ b/wrappers/javascript/lerna.json
@@ -1,7 +1,7 @@
 {
   "$schema": "node_modules/lerna/schemas/lerna-schema.json",
   "packages": ["indy-vdr-*"],
-  "version": "0.2.0",
+  "version": "0.2.1",
   "npmClient": "yarn",
   "command": {
     "version": {


### PR DESCRIPTION
Indy VDR does not allow a value of `0` to be passed, and the jsiToValue uses `0` as a default value if the value wasn't provided and it's optional. Same as is done in the Node.JS wrapper we convert the value to -1 (indicating it has no value).

