### PR TITLE
fix(js): update ffi-napi

### DIFF
--- a/wrappers/javascript/indy-vdr-nodejs/package.json
+++ b/wrappers/javascript/indy-vdr-nodejs/package.json
@@ -31,7 +31,6 @@
     "@babel/runtime": "^7.12.5",
     "@types/jest": "^27.4.1",
     "@types/node": "^17.0.26",
-    "@types/ref-array-di": "^1.2.5",
     "@types/ref-struct-di": "^1.1.6",
     "babel-plugin-module-resolver": "^4.0.0",
     "jest": "^28.0.2",
@@ -40,7 +39,7 @@
     "typescript": "~4.9.4"
   },
   "dependencies": {
-    "@2060.io/ffi-napi": "4.0.8",
+    "@2060.io/ffi-napi": "4.0.9",
     "@2060.io/ref-napi": "3.0.6",
     "@hyperledger/indy-vdr-shared": "0.2.0-dev.6",
     "@mapbox/node-pre-gyp": "^1.0.10",

--- a/wrappers/javascript/yarn.lock
+++ b/wrappers/javascript/yarn.lock
@@ -2,10 +2,10 @@
 # yarn lockfile v1
 
 
-"@2060.io/ffi-napi@4.0.8":
-  version "4.0.8"
-  resolved "https://registry.yarnpkg.com/@2060.io/ffi-napi/-/ffi-napi-4.0.8.tgz#ec3424d9ec979491b41b8d82514ae82a647da8b0"
-  integrity sha512-sONRKLtxFKN5PXuZaa41b/kTN+R5qAh6PAL15/fnafnvAKQ5WBoxRIy8xRh8jo9mydywtt4IrWtatB93w0+3cA==
+"@2060.io/ffi-napi@4.0.9":
+  version "4.0.9"
+  resolved "https://registry.yarnpkg.com/@2060.io/ffi-napi/-/ffi-napi-4.0.9.tgz#194fca2132932ba02e62d716c786d20169b20b8d"
+  integrity sha512-JfVREbtkJhMXSUpya3JCzDumdjeZDCKv4PemiWK+pts5CYgdoMidxeySVlFeF5pHqbBpox4I0Be7sDwAq4N0VQ==
   dependencies:
     "@2060.io/ref-napi" "^3.0.6"
     debug "^4.1.1"


### PR DESCRIPTION
Updated `ffi-napi` dependency on JS wrapper in order to fix the incompatibility issue found with newer node.js versions. See https://github.com/nodejs/node/issues/52240#issuecomment-2040598178.