### PR TITLE
chore: update minSdkVersion to get the project version or fallback to 21

### DIFF
--- a/wrappers/javascript/indy-vdr-react-native/android/build.gradle
+++ b/wrappers/javascript/indy-vdr-react-native/android/build.gradle
@@ -59,6 +59,10 @@ def getExt(name) {
   return rootProject.ext.get(name)
 }
 
+def getExtWithFallback(prop, fallback) {
+  return rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
+}
+
 def resolveBuildType() {
     def buildType = "debug"
     tasks.all({ task ->
@@ -81,7 +85,7 @@ android {
   }
   
   defaultConfig {
-    minSdkVersion 21 
+    minSdkVersion getExtWithFallback('minSdkVersion', '21') 
     targetSdkVersion getExt('targetSdkVersion')
     
     externalNativeBuild {


### PR DESCRIPTION
This PR updates the react-native wrapper to get the minSdkVersion from the project config or fallback to the current hardcoded version. @TimoGlastra @berendsliedrecht 