### PR TITLE
feat: added improved gh actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -427,7 +427,7 @@ jobs:
             library-x86_64-linux-android
           failOnError: false
 
-  release-alpha:
+  alpha-release:
     name: Alpha Release
     if: github.event_name == 'push'
     permissions:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -427,6 +427,57 @@ jobs:
             library-x86_64-linux-android
           failOnError: false
 
+  release-alpha:
+    name: Alpha Release
+    if: github.event_name == 'push'
+    permissions:
+      id-token: write
+    runs-on: ubuntu-latest
+    env:
+      NPM_TAG: 'alpha'
+    needs: 
+      - create-ios-xcframework
+      - create-android-library
+    defaults:
+      run:
+        working-directory: ./wrappers/javascript
+    timeout-minutes: 7
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20.x'
+          registry-url: 'https://registry.npmjs.org'
+          cache: "yarn"
+          cache-dependency-path: "wrappers/javascript"
+      - name: install
+        run: yarn install
+
+      - name: Fetch Android libraries
+        uses: actions/download-artifact@v4
+        with:
+          name: android-libraries
+          path: indy-vdr-react-native/native/mobile/android/
+
+      - name: Fetch iOS Framework
+        uses: actions/download-artifact@v4
+        with:
+          name: indy_vdr.xcframework
+          path: indy-vdr-react-native/native/mobile/ios/
+
+      # On push to main, release unstable version
+      - name: Release alpha
+        run: |
+          git update-index --assume-unchanged $(find . -type d -name node_modules -prune -o -name 'package.json' -print | tr "\n" " ")
+          #export NEXT_VERSION_BUMP=$(yarn next-version-bump)
+          export NEXT_VERSION_BUMP="major"
+          npx lerna publish --no-verify-access --no-private --loglevel=verbose --canary $NEXT_VERSION_BUMP --dist-tag $NPM_TAG --force-publish --yes
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_PUBLISH }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_PUBLISH }}
+
   create-ios-android-release-asset:
     name: Create iOS and Android release assets
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -429,7 +429,7 @@ jobs:
 
   alpha-release:
     name: Alpha Release
-    if: github.event_name == 'push'
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     permissions:
       id-token: write
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -253,7 +253,7 @@ jobs:
           name: library-linux-x86_64
 
       - name: Install dependencies
-        run: yarn install
+        run: yarn install --immutable
 
       - name: Build
         run: yarn build
@@ -453,7 +453,7 @@ jobs:
           cache: "yarn"
           cache-dependency-path: "wrappers/javascript"
       - name: install
-        run: yarn install
+        run: yarn install --immutable
 
       - name: Fetch Android libraries
         uses: actions/download-artifact@v4

--- a/wrappers/javascript/indy-vdr-nodejs/package.json
+++ b/wrappers/javascript/indy-vdr-nodejs/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "@hyperledger/indy-vdr-nodejs",
-  "version": "0.2.0-dev.6",
+  "name": "@wadeking98/indy-vdr-nodejs",
+  "version": "0.1.0",
   "license": "Apache-2.0",
   "description": "Nodejs wrapper for Indy Vdr",
   "source": "src/index",
@@ -9,7 +9,7 @@
   "author": "Hyperledger (https://github.com/hyperledger)",
   "repository": {
     "type": "git",
-    "url": "https://github.com/hyperledger/indy-vdr",
+    "url": "https://github.com/wadeking98/indy-vdr",
     "directory": "wrappers/javascript/indy-vdr-nodejs"
   },
   "publishConfig": {

--- a/wrappers/javascript/indy-vdr-nodejs/package.json
+++ b/wrappers/javascript/indy-vdr-nodejs/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "@wadeking98/indy-vdr-nodejs",
-  "version": "0.1.0",
+  "name": "@hyperledger/indy-vdr-nodejs",
+  "version": "0.2.2",
   "license": "Apache-2.0",
   "description": "Nodejs wrapper for Indy Vdr",
   "source": "src/index",
@@ -9,7 +9,7 @@
   "author": "Hyperledger (https://github.com/hyperledger)",
   "repository": {
     "type": "git",
-    "url": "https://github.com/wadeking98/indy-vdr",
+    "url": "https://github.com/hyperledger/indy-vdr",
     "directory": "wrappers/javascript/indy-vdr-nodejs"
   },
   "publishConfig": {

--- a/wrappers/javascript/indy-vdr-react-native/native/indy_vdr.node
+++ b/wrappers/javascript/indy-vdr-react-native/native/indy_vdr.node
@@ -1,3 +1,0 @@
-# This is a placeholder file to prevent node-pre-gyp from installing the indy_vdr binary when cloning
-# this repository. It won't be published to NPM, meaning when you download this package from npm it
-# will try to download the binary.

--- a/wrappers/javascript/indy-vdr-react-native/package.json
+++ b/wrappers/javascript/indy-vdr-react-native/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "@wadeking98/indy-vdr-react-native",
-  "version": "0.1.0",
+  "name": "@hyperledger/indy-vdr-react-native",
+  "version": "0.2.2",
   "license": "Apache-2.0",
   "description": "React Native wrapper for Indy Vdr",
   "source": "src/index",
@@ -9,7 +9,7 @@
   "author": "Hyperledger (https://github.com/hyperledger)",
   "repository": {
     "type": "git",
-    "url": "https://github.com/wadeking98/indy-vdr",
+    "url": "https://github.com/hyperledger/indy-vdr",
     "directory": "wrappers/javascript/indy-vdr-react-native"
   },
   "publishConfig": {

--- a/wrappers/javascript/indy-vdr-react-native/package.json
+++ b/wrappers/javascript/indy-vdr-react-native/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "@hyperledger/indy-vdr-react-native",
-  "version": "0.2.0-dev.6",
+  "name": "@wadeking98/indy-vdr-react-native",
+  "version": "0.1.0",
   "license": "Apache-2.0",
   "description": "React Native wrapper for Indy Vdr",
   "source": "src/index",
@@ -9,7 +9,7 @@
   "author": "Hyperledger (https://github.com/hyperledger)",
   "repository": {
     "type": "git",
-    "url": "https://github.com/hyperledger/indy-vdr",
+    "url": "https://github.com/wadeking98/indy-vdr",
     "directory": "wrappers/javascript/indy-vdr-react-native"
   },
   "publishConfig": {
@@ -28,6 +28,7 @@
     "ios/indyVdr.xcodeproj/project.pbxproj",
     "cpp/**/*.cpp",
     "cpp/**/*.h",
+    "native/**",
     "indy-vdr.podspec",
     "README.md",
     "LICENSE",
@@ -36,12 +37,10 @@
   "scripts": {
     "build": "yarn clean && yarn compile",
     "clean": "rimraf -rf ./build",
-    "compile": "tsc -p tsconfig.build.json",
-    "install": "node-pre-gyp install"
+    "compile": "tsc -p tsconfig.build.json"
   },
   "dependencies": {
-    "@hyperledger/indy-vdr-shared": "0.2.0-dev.6",
-    "@mapbox/node-pre-gyp": "^1.0.10"
+    "@hyperledger/indy-vdr-shared": "0.2.0-dev.6"
   },
   "devDependencies": {
     "@types/react": "^16.9.19",
@@ -54,12 +53,5 @@
   "peerDependencies": {
     "react": ">= 16",
     "react-native": ">= 0.66.0"
-  },
-  "binary": {
-    "module_name": "indy_vdr",
-    "module_path": "native",
-    "remote_path": "v0.4.0",
-    "host": "https://github.com/hyperledger/indy-vdr/releases/download/",
-    "package_name": "library-ios-android.tar.gz"
   }
 }

--- a/wrappers/javascript/indy-vdr-shared/package.json
+++ b/wrappers/javascript/indy-vdr-shared/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "@wadeking98/indy-vdr-shared",
-  "version": "0.1.0",
+  "name": "@hyperledger/indy-vdr-shared",
+  "version": "0.2.2",
   "license": "Apache-2.0",
   "description": "Shared library for using Indy VDR with NodeJS and React Native",
   "main": "build/index",
@@ -8,7 +8,7 @@
   "homepage": "https://github.com/hyperledger/indy-vdr/tree/main/wrappers/javascript/indy-vdr-shared",
   "repository": {
     "type": "git",
-    "url": "https://github.com/wadeking98/indy-vdr",
+    "url": "https://github.com/hyperledger/indy-vdr",
     "directory": "wrappers/javascript/indy-vdr-shared"
   },
   "publishConfig": {

--- a/wrappers/javascript/indy-vdr-shared/package.json
+++ b/wrappers/javascript/indy-vdr-shared/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "@hyperledger/indy-vdr-shared",
-  "version": "0.2.0-dev.6",
+  "name": "@wadeking98/indy-vdr-shared",
+  "version": "0.1.0",
   "license": "Apache-2.0",
   "description": "Shared library for using Indy VDR with NodeJS and React Native",
   "main": "build/index",
@@ -8,7 +8,7 @@
   "homepage": "https://github.com/hyperledger/indy-vdr/tree/main/wrappers/javascript/indy-vdr-shared",
   "repository": {
     "type": "git",
-    "url": "https://github.com/hyperledger/indy-vdr",
+    "url": "https://github.com/wadeking98/indy-vdr",
     "directory": "wrappers/javascript/indy-vdr-shared"
   },
   "publishConfig": {

--- a/wrappers/javascript/lerna.json
+++ b/wrappers/javascript/lerna.json
@@ -1,7 +1,7 @@
 {
   "$schema": "node_modules/lerna/schemas/lerna-schema.json",
   "packages": ["indy-vdr-*"],
-  "version": "0.2.0-dev.6",
+  "version": "0.2.2",
   "npmClient": "yarn",
   "command": {
     "version": {

--- a/wrappers/javascript/yarn.lock
+++ b/wrappers/javascript/yarn.lock
@@ -931,6 +931,11 @@
   resolved "https://registry.yarnpkg.com/@hutson/parse-repository-url/-/parse-repository-url-3.0.2.tgz#98c23c950a3d9b6c8f0daed06da6c3af06981340"
   integrity sha512-H9XAx3hc0BQHY6l+IFSWHDySypcXsvsuLhgYLUGywmJ5pswRVQJUHpOsobnLYp2ZUaUlKiKDrgWWhosOwAEM8Q==
 
+"@hyperledger/indy-vdr-shared@0.2.0-dev.6":
+  version "0.2.0-dev.6"
+  resolved "https://registry.yarnpkg.com/@hyperledger/indy-vdr-shared/-/indy-vdr-shared-0.2.0-dev.6.tgz#4954ee06fa8a2e4545b35cd525b7b86e0f10b6fe"
+  integrity sha512-pNLq0zkqv5rFCpU9tzyJ5DPvED5YE+UFP8iKwVD7fe+mAD6/VpweOunYNKgIBT4K1DYI21q7bs3SzxQZ0hLlKw==
+
 "@isaacs/cliui@^8.0.2":
   version "8.0.2"
   resolved "https://registry.yarnpkg.com/@isaacs/cliui/-/cliui-8.0.2.tgz#b37667b7bc181c168782259bab42474fbf52b550"


### PR DESCRIPTION
Added github actions to automatically publish alpha versions to npm.
Included binaries in react native package so we have a smoother release cycle without having to wait for a binary release

This PR does not effect the usual release cycle, this only adds alpha releases. Normal major releases will still have to be triggered manually