### PR TITLE
Update Cargo.toml time package

### DIFF
--- a/libindy_vdr/Cargo.toml
+++ b/libindy_vdr/Cargo.toml
@@ -57,7 +57,7 @@ serde_json = "1.0"
 sha2 = "0.10"
 sha3 = "0.10"
 thiserror = "1.0"
-time = { version = "=0.3.20", features = ["parsing"] }
+time = { version = "=0.3.36", features = ["parsing"] }
 url = "2.2.2"
 zmq = "0.9"
 sled = "0.34.7"


### PR DESCRIPTION
I think this should fix the mac build errors, though I'm still not sure why it's only happening on mac