### PR TITLE
Loosen time dependency patch version constraint 

### DIFF
--- a/libindy_vdr/Cargo.toml
+++ b/libindy_vdr/Cargo.toml
@@ -57,14 +57,13 @@ serde_json = "1.0"
 sha2 = "0.10"
 sha3 = "0.10"
 thiserror = "1.0"
-time = { version = "=0.3.36", features = ["parsing"] }
+time = { version = "0.3.36", features = ["parsing"] }
 url = "2.2.2"
 zmq = "0.9"
 sled = "0.34.7"
 
 [dev-dependencies]
 rstest = "0.18"
-time = "0.3"
 indy-data-types = { version = "0.7", default-features = false, features = [
     "rich_schema",
 ] }


### PR DESCRIPTION
Previously we were locked into time `=0.3.20`: https://github.com/hyperledger/indy-vdr/pull/166

Recently it was updated to `=0.3.36` due to issues with rust 1.80 and <0.3.36 versions of time.

However just as a crate cleanliness, it would be nice to only pin the version to 0.3.36 if we absolutely have to, dep conflicts may arise for consumers of the indy-vdr in the future as a result etc

FYI @andrewwhitehead : RE your [original decision](https://github.com/hyperledger/indy-vdr/pull/166) to lock the time version, is it still necessary?