### PR TITLE
rust 1.81 update

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,7 +1,7 @@
 name: "Indy-VDR"
 
 env:
-  RUST_VERSION: "1.80.0"
+  RUST_VERSION: "1.81.0"
   CROSS_VERSION: "0.2.5"
 
 on:
@@ -42,7 +42,7 @@ jobs:
     name: Run checks
     strategy:
       matrix:
-        os: [macos-latest, windows-latest, ubuntu-latest]
+        os: [macos-13, windows-latest, ubuntu-latest]
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -127,7 +127,7 @@ jobs:
             # using cross here to build against an older glibc for compatibility
             use_cross: true
           - architecture: darwin-universal
-            os: macos-latest
+            os: macos-13
             lib: libindy_vdr.dylib
             target: darwin-universal
             # As of Rust 1.80, aarch64-apple-darwin is stable
@@ -298,7 +298,7 @@ jobs:
   build-ios:
     name: Build library (iOS)
     needs: [checks]
-    runs-on: macos-latest
+    runs-on: macos-13
     strategy:
       matrix:
         target: [aarch64-apple-ios, aarch64-apple-ios-sim, x86_64-apple-ios]
@@ -321,7 +321,13 @@ jobs:
 
       - name: Build
         run: |
+          # Set RUSTFLAGS to cap lints at warning level to prevent warnings from becoming errors
+          export RUSTFLAGS="--cap-lints=warn"
           cargo build --lib --release --target ${{ matrix.target }} --package indy-vdr
+
+      - name: List files in target
+        run: |
+          ls -la target/${{ matrix.target }}/release/
 
       - name: Save library
         uses: actions/upload-artifact@v4
@@ -331,7 +337,7 @@ jobs:
 
   create-ios-xcframework:
     name: Create iOS xcframework
-    runs-on: macos-latest
+    runs-on: macos-13
     needs: build-ios
 
     steps:
@@ -341,10 +347,21 @@ jobs:
       - name: Fetch static libraries
         uses: actions/download-artifact@v4
 
+      - name: Debug - List downloaded files
+        run: find . -name "*.a" | sort
+
+      - name: Debug - Show directory structure
+        run: |
+          ls -la
+          ls -la library-aarch64-apple-ios
+          ls -la library-aarch64-apple-ios-sim  
+          ls -la library-x86_64-apple-ios
+
       - run: >
           ./build-xcframework.sh library-aarch64-apple-ios \
                                  library-aarch64-apple-ios-sim \
                                  library-x86_64-apple-ios
+
       - name: Save xcframework
         uses: actions/upload-artifact@v4
         with:
@@ -362,7 +379,6 @@ jobs:
   build-android:
     name: Build library (Android)
     needs: [checks]
-    # Updated to use modern NDK for Rust 1.80+
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -384,9 +400,16 @@ jobs:
           toolchain: ${{ env.RUST_VERSION }}
           targets: ${{ matrix.target }}
 
+      - name: Cache cargo resources
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: deps
+          save-if: false
+
       - name: Build
         run: |
           cargo install --bins --git https://github.com/rust-embedded/cross --locked --tag v${{ env.CROSS_VERSION }} cross
+          # Using default Cross images since custom ones were removed from Cross.toml
           cross build --lib --release --target ${{matrix.target}} --package indy-vdr
 
       - name: Save library
@@ -477,7 +500,7 @@ jobs:
           - os: ubuntu-latest
             architecture: linux-x86_64
             plat-name: manylinux2014_x86_64
-          - os: macos-latest
+          - os: macos-13
             architecture: darwin-universal
             plat-name: macosx_10_9_universal2
           - os: windows-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,8 +1,8 @@
 name: "Indy-VDR"
 
 env:
-  RUST_VERSION: "1.70.0"
-  CROSS_VERSION: "0.2.4"
+  RUST_VERSION: "1.80.0"
+  CROSS_VERSION: "0.2.5"
 
 on:
   push:
@@ -42,7 +42,7 @@ jobs:
     name: Run checks
     strategy:
       matrix:
-        os: [macos-12, windows-latest, ubuntu-latest]
+        os: [macos-latest, windows-latest, ubuntu-latest]
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -127,11 +127,11 @@ jobs:
             # using cross here to build against an older glibc for compatibility
             use_cross: true
           - architecture: darwin-universal
-            os: macos-12
+            os: macos-latest
             lib: libindy_vdr.dylib
             target: darwin-universal
-            # beta or nightly required for aarch64-apple-darwin target
-            toolchain: beta
+            # As of Rust 1.80, aarch64-apple-darwin is stable
+            toolchain: stable
           - architecture: windows-x86_64
             os: windows-latest
             lib: indy_vdr.dll
@@ -298,7 +298,7 @@ jobs:
   build-ios:
     name: Build library (iOS)
     needs: [checks]
-    runs-on: macos-12
+    runs-on: macos-latest
     strategy:
       matrix:
         target: [aarch64-apple-ios, aarch64-apple-ios-sim, x86_64-apple-ios]
@@ -331,7 +331,7 @@ jobs:
 
   create-ios-xcframework:
     name: Create iOS xcframework
-    runs-on: macos-12
+    runs-on: macos-latest
     needs: build-ios
 
     steps:
@@ -362,10 +362,7 @@ jobs:
   build-android:
     name: Build library (Android)
     needs: [checks]
-    # NB: RUST_VERSION must be <1.68 here to support NDK 17
-    env:
-      RUST_VERSION: "1.67"
-
+    # Updated to use modern NDK for Rust 1.80+
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -385,6 +382,7 @@ jobs:
         uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ env.RUST_VERSION }}
+          targets: ${{ matrix.target }}
 
       - name: Build
         run: |
@@ -479,9 +477,9 @@ jobs:
           - os: ubuntu-latest
             architecture: linux-x86_64
             plat-name: manylinux2014_x86_64
-          - os: macos-12
+          - os: macos-latest
             architecture: darwin-universal
-            plat-name: macosx_10_9_universal2 # macosx_10_9_x86_64
+            plat-name: macosx_10_9_universal2
           - os: windows-latest
             architecture: windows-x86_64
             plat-name: win_amd64
@@ -515,8 +513,6 @@ jobs:
         working-directory: wrappers/python
 
       - name: Test python package
-        # FIXME cross platform test the python package
-        # maybe use the cross docker image?
         if: ${{ matrix.architecture != 'linux-aarch64' }}
         shell: sh
         run: |

--- a/Cross.toml
+++ b/Cross.toml
@@ -4,14 +4,4 @@ image = "ghcr.io/rust-cross/manylinux2014-cross:aarch64"
 [target.x86_64-unknown-linux-gnu]
 image = "ghcr.io/rust-cross/manylinux2014-cross:x86_64"
 
-[target.x86_64-linux-android]
-image = "ghcr.io/hyperledger/aries-builder-images/cross/x86_64-linux-android:main"
 
-[target.i686-linux-android]
-image = "ghcr.io/hyperledger/aries-builder-images/cross/i686-linux-android:main"
-
-[target.aarch64-linux-android]
-image = "ghcr.io/hyperledger/aries-builder-images/cross/aarch64-linux-android:main"
-
-[target.armv7-linux-androideabi]
-image = "ghcr.io/hyperledger/aries-builder-images/cross/armv7-linux-androideabi:main"

--- a/libindy_vdr/Cargo.toml
+++ b/libindy_vdr/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "indy-vdr"
-version = "0.4.3"
+version = "0.4.4"
 authors = [
     "Hyperledger Indy Contributors <hyperledger-indy@lists.hyperledger.org>",
 ]
@@ -30,10 +30,10 @@ default = ["ffi", "log", "zmq_vendored"]
 # This is added so we can lock the version that zmq uses
 # 0.1.49 is broken for ios targets
 cmake = { version = "=0.1.48", optional = true }
-base64 = "0.21"
+base64 = "0.22"
 bs58 = "0.5"
 etcommon-rlp = "0.2.4"
-env_logger = { version = "0.10", optional = true }
+env_logger = { version = "0.11", optional = true }
 ffi-support = { version = "0.4", optional = true }
 futures-channel = "0.3"
 futures-executor = "0.3"
@@ -63,7 +63,7 @@ zmq = "0.9"
 sled = "0.34.7"
 
 [dev-dependencies]
-rstest = "0.18"
+rstest = "0.25"
 indy-data-types = { version = "0.7", default-features = false, features = [
     "rich_schema",
 ] }

--- a/wrappers/golang/cmd/demo/demo.go
+++ b/wrappers/golang/cmd/demo/demo.go
@@ -26,7 +26,7 @@ func main() {
 }
 
 func readOnlyDemo() {
-	genesisFile, err := http.Get("https://raw.githubusercontent.com/sovrin-foundation/sovrin/master/sovrin/pool_transactions_builder_genesis")
+	genesisFile, err := http.Get("https://raw.githubusercontent.com/Indicio-tech/indicio-network/main/genesis_files/pool_transactions_testnet_genesis")
 	if err != nil {
 		log.Fatalln(err)
 	}
@@ -50,7 +50,7 @@ func readOnlyDemo() {
 	d, _ := json.MarshalIndent(status, " ", " ")
 	fmt.Println(string(d))
 
-	rply, err := client.GetNym("FzAaV9Waa1DccDa72qwg13")
+	rply, err := client.GetNym("345seGJDVMwcPhgpHAZb7u")
 	if err != nil {
 		log.Fatalln(err)
 	}

--- a/wrappers/python/demo/test.py
+++ b/wrappers/python/demo/test.py
@@ -197,7 +197,7 @@ async def basic_test(transactions_path):
     # --- DID Resolution ---
 
     # The DID resolver can be initialized with a dict containing namespaces and pool instances:
-    # pool_map = await open_pools(ledgers=["idunion", "sovrin:builder"])
+    # pool_map = await open_pools(ledgers=["idunion", "indicio:testnet"])
     # resolver = Resolver(pool_map)
 
     # In addition, the the DID resolver can be started with autopilot = True.
@@ -205,12 +205,12 @@ async def basic_test(transactions_path):
     # for the given did:indy namespace.
     resolver = Resolver(autopilot=True)
 
-    log("Resolve DID did:indy:idunion:test:APs6Xd2GH8FNwCaXDw6Qm2")
-    doc = await resolver.resolve("did:indy:idunion:test:Fhbr2wQrJeB1UcZeFKpG5F")
+    log("Resolve DID did:indy:indicio:test:345seGJDVMwcPhgpHAZb7u")
+    doc = await resolver.resolve("did:indy:indicio:test:345seGJDVMwcPhgpHAZb7u")
     log(json.dumps(doc, indent=2))
 
     try:
-        doc = await resolver.resolve("did:indy:idunion:test:APs6Xd2GH8FNwCaXDw6Qm2")
+        doc = await resolver.resolve("did:indy:indicio:test:345seGJDVMwcPhgpHAZb7u")
     except VdrError as err:
         print(err)
 
@@ -232,12 +232,12 @@ def get_script_dir():
     return os.path.dirname(os.path.realpath(__file__))
 
 
-def download_buildernet_genesis_file():
+def download_indicio_testnet_genesis_file():
     genesis_file_url = (
-        "https://raw.githubusercontent.com/sovrin-foundation/"
-        "sovrin/master/sovrin/pool_transactions_builder_genesis"
+        "https://raw.githubusercontent.com/Indicio-tech/indicio-network/main/"
+        "genesis_files/pool_transactions_testnet_genesis"
     )
-    target_local_path = f"{get_script_dir()}/genesis_sov_buildernet.txn"
+    target_local_path = f"{get_script_dir()}/genesis_indicio_testnet.txn"
     urllib.request.urlretrieve(genesis_file_url, target_local_path)
     return target_local_path
 
@@ -246,6 +246,6 @@ if __name__ == "__main__":
     log("indy-vdr version:", version())
 
     genesis_path = (
-        sys.argv[1] if len(sys.argv) > 1 else download_buildernet_genesis_file()
+        sys.argv[1] if len(sys.argv) > 1 else download_indicio_testnet_genesis_file()
     )
     asyncio.get_event_loop().run_until_complete(basic_test(genesis_path))


### PR DESCRIPTION
PR for an update to use rust 1.81.(to be in sync with askar, and also crate a new release since indy-vdr 0.4.3 doesn't compile with rust 1.80+)  Hopefully I didn't miss anything.  The JS wrapper, I haven't checked though,.  Tests are green for it but that is all I can say about it, my JS skills are really, really rusty.

No logic code was changed in indy-vdr.

- Updated rust version to v1.81 and cross to 0.2.5
- Updated python/go wrapper tests to use indicio network since sovrin is going down and is currently unreliable for tests
- updated rust libraries that do not have any breaking changes
- update macos image to macos-13. This is the last image that can still build x86_64 intel for mac.
- updated the indy-vdr crate version to 0.4.4 
